### PR TITLE
Add extensive Upsales API wrapper module.

### DIFF
--- a/__tests__/src/api/upsales/appConfig-test.js
+++ b/__tests__/src/api/upsales/appConfig-test.js
@@ -1,0 +1,229 @@
+const errorsHelper = require('../../../../src/helpers/errorsHelper');
+const logger = require('../../../../src/helpers/log');
+
+const getAppConfig = () => ({
+	configJson: JSON.stringify({
+		configField1: 'value1',
+		configField2: 'value2',
+		configField3: 'value3'
+	})
+});
+
+const getSavedAppConfig = () => ({
+	configJson: JSON.stringify({
+		configField1: 'value1',
+		configField2: 'value2',
+		configField3: 'value3'
+	})
+});
+
+const getAppConfigChanges = () => ([
+	{ name: 'configField2', value: 'newval2' },
+	{ name: 'configField4', value: 100 },
+	{ name: 'configField5', value: [ 10, 20, 30 ] }
+]);
+
+const getNoneAppConfigChanges = () => ([
+	{ name: 'configField3', value: 'value3' },
+	{ name: 'configField2', value: 'value2' }
+]);
+
+const getUpdatedAppConfig = () => ({
+	configJson: JSON.stringify({
+		configField1: 'value1',
+		configField2: 'newval2',
+		configField3: 'value3',
+		configField4: 100,
+		configField5: [ 10, 20, 30 ]
+	})
+});
+
+const getAppConfigResponse = () => ({
+	data: {
+		data: getAppConfig()
+	}
+});
+
+const getSavedAppConfigResponse = () => ({
+	data: getSavedAppConfig()
+});
+
+const getUpdatedAppConfigResponse = () => ({
+	data: getUpdatedAppConfig()
+});
+
+const API_KEY = 'TEST_API_KEY';
+const INTEGRATION_ID = 277;
+
+
+describe('src/api/upsales/appConfig.js: load', () => {
+	beforeEach(() => {
+		jest.resetModules();
+		jest.mock('axios');
+  });
+
+
+	it('load should send GET request to acquire App config from Upsales', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/appConfig');
+		const axios = require('axios');
+		axios.get.mockResolvedValue(getAppConfigResponse());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, integrationId: INTEGRATION_ID }, { axios,	errorsHelper,	logger });
+
+		const appConfig = await upsalesApi.load();
+
+		expect(appConfig).toEqual(getAppConfig());
+		expect(axios.get.mock.calls).toEqual([ [ 'https://power.upsales.com/api/v2/standardIntegrationSettings/' + INTEGRATION_ID + '?token=' + API_KEY ] ]);
+	});
+
+
+	it('load should throw LOAD_UPSALES_APP_CONFIG_ERROR exception in case of axios promise rejection', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/appConfig');
+		const axios = require('axios');
+		axios.get.mockRejectedValue('Some error');
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, integrationId: INTEGRATION_ID }, { axios,	errorsHelper,	logger });
+
+		try {
+			await upsalesApi.load();
+			expect(true).toBe(false);
+		} catch (err) {
+			expect(err.code).toBe('LOAD_UPSALES_APP_CONFIG_ERROR')
+		}
+	});
+
+});
+
+
+
+describe('src/api/upsales/appConfig.js: save', () => {
+	beforeEach(() => {
+		jest.resetModules();
+		jest.mock('axios');
+  });
+
+
+	it('save should send PUT request to save App config to Upsales', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/appConfig');
+		const axios = require('axios');
+		axios.put.mockResolvedValue(getSavedAppConfigResponse());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, integrationId: INTEGRATION_ID }, { axios,	errorsHelper,	logger });
+
+		const updatedAppConfig = await upsalesApi.save(getAppConfig());
+
+		expect(updatedAppConfig).toEqual(getSavedAppConfig());
+		expect(axios.put.mock.calls).toEqual([ [ 'https://power.upsales.com/api/v2/standardIntegrationSettings/' + INTEGRATION_ID + '?token=' + API_KEY, getAppConfig() ] ]);
+	});
+
+
+	it('save should throw SAVE_UPSALES_APP_CONFIG_ERROR exception in case of axios promise rejection', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/appConfig');
+		const axios = require('axios');
+		axios.put.mockRejectedValue('Some error');
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, integrationId: INTEGRATION_ID }, { axios,	errorsHelper,	logger });
+
+		try {
+			const updatedAppConfig = await upsalesApi.save(getAppConfig());
+			expect(true).toBe(false);
+		} catch (err) {
+			expect(err.code).toBe('SAVE_UPSALES_APP_CONFIG_ERROR')
+		}
+	});
+
+});
+
+describe('src/api/upsales/appConfig.js: updateFields', () => {
+	beforeEach(() => {
+		jest.resetModules();
+		jest.mock('axios');
+  });
+
+
+	it('updateFields should send GET request to acquire App config from Upsales', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/appConfig');
+		const axios = require('axios');
+		axios.get.mockResolvedValue(getAppConfigResponse());
+		axios.put.mockResolvedValue(getUpdatedAppConfigResponse());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, integrationId: INTEGRATION_ID }, { axios,	errorsHelper,	logger });
+
+		await upsalesApi.updateFields(getAppConfigChanges());
+
+		expect(axios.get.mock.calls).toEqual([ [ 'https://power.upsales.com/api/v2/standardIntegrationSettings/' + INTEGRATION_ID + '?token=' + API_KEY ] ]);
+	});
+
+
+	it('updateFields should change only specified fields in App config', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/appConfig');
+		const axios = require('axios');
+		axios.get.mockResolvedValue(getAppConfigResponse());
+		axios.put.mockResolvedValue(getUpdatedAppConfigResponse());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, integrationId: INTEGRATION_ID }, { axios,	errorsHelper,	logger });
+
+		await upsalesApi.updateFields(getAppConfigChanges());
+
+		expect(axios.put.mock.calls).toEqual([ [ 'https://power.upsales.com/api/v2/standardIntegrationSettings/' + INTEGRATION_ID + '?token=' + API_KEY, getUpdatedAppConfig() ] ]);
+	});
+
+
+	it('updateFields should return true if app config had to be changed', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/appConfig');
+		const axios = require('axios');
+		axios.get.mockResolvedValue(getAppConfigResponse());
+		axios.put.mockResolvedValue(getUpdatedAppConfigResponse());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, integrationId: INTEGRATION_ID }, { axios,	errorsHelper,	logger });
+
+		const hasChanged = await upsalesApi.updateFields(getAppConfigChanges());
+
+		expect(hasChanged).toEqual(true);
+	});
+
+
+	it('updateFields should return false if app config had not to be changed', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/appConfig');
+		const axios = require('axios');
+		axios.get.mockResolvedValue(getAppConfigResponse());
+		axios.put.mockResolvedValue(getUpdatedAppConfigResponse());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, integrationId: INTEGRATION_ID }, { axios,	errorsHelper,	logger });
+
+		const hasChanged = await upsalesApi.updateFields(getNoneAppConfigChanges());
+
+		expect(hasChanged).toEqual(false);
+	});
+
+
+	it('updateFields should not save app config it had not to be changed', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/appConfig');
+		const axios = require('axios');
+		axios.get.mockResolvedValue(getAppConfigResponse());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, integrationId: INTEGRATION_ID }, { axios,	errorsHelper,	logger });
+
+		const hasChanged = await upsalesApi.updateFields(getNoneAppConfigChanges());
+
+		expect(axios.put.mock.calls.length).toEqual(0);
+	});
+
+
+	it('updateFields should throw UPDATE_UPSALES_APP_CONFIG_ERROR exception in case of axios promise rejection', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/appConfig');
+		const axios = require('axios');
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, integrationId: INTEGRATION_ID }, { axios,	errorsHelper,	logger });
+
+		axios.get.mockResolvedValue(getAppConfigResponse());
+		axios.put.mockRejectedValue('Some error');
+		try {
+			await upsalesApi.updateFields(getAppConfigChanges());
+			expect(true).toBe(false);
+		} catch (err) {
+			expect(err.code).toBe('UPDATE_UPSALES_APP_CONFIG_ERROR')
+		}
+
+		axios.get.mockResolvedValue('Some error');
+		axios.put.mockResolvedValue(getUpdatedAppConfigResponse());
+		try {
+			await upsalesApi.updateFields(getAppConfigChanges());
+			expect(true).toBe(false);
+		} catch (err) {
+			expect(err.code).toBe('UPDATE_UPSALES_APP_CONFIG_ERROR')
+		}
+
+	});
+
+});

--- a/__tests__/src/api/upsales/clientParam-test.js
+++ b/__tests__/src/api/upsales/clientParam-test.js
@@ -1,0 +1,60 @@
+const errorsHelper = require('../../../../src/helpers/errorsHelper');
+const logger = require('../../../../src/helpers/log');
+
+const API_KEY = 'TEST_API_KEY';
+const PARAM_ID = 100;
+const PARAM_VALUE = 'SOME VALUE';
+
+const getClientParamOptions = () => {
+	return {
+		method: 'PUT',
+		url: `https://power.upsales.com/api/v2/master/clientParam/${PARAM_ID}`,
+		headers: {
+			'Cookie': `token=${API_KEY}`,
+			'Content-Type': 'application/json'
+		},
+		data: PARAM_VALUE
+	};
+};
+
+const getClientParameterPutResponse = () => {
+	return {
+		data: 'SOME_RESULT'
+	};
+};
+
+
+
+describe('src/api/upsales/clientParam.js: set', () => {
+	beforeEach(() => {
+		jest.resetModules();
+		jest.mock('axios');
+  });
+
+	it('set should send correct PUT request to Upsales to change parameter value', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/clientParam');
+		const axios = require('axios');
+		axios.mockResolvedValue(getClientParameterPutResponse());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY }, { axios,	errorsHelper,	logger });
+
+		const upsalesResponse = await upsalesApi.set(PARAM_ID, PARAM_VALUE);
+
+		expect(upsalesResponse).toEqual(getClientParameterPutResponse().data);
+		expect(axios.mock.calls[0]).toEqual([ getClientParamOptions() ]);
+	});
+
+	it('set should throw exception in case of axios promise rejection', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/clientParam');
+		const axios = require('axios');
+		axios.mockRejectedValue('Some error');
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY }, { axios,	errorsHelper,	logger });
+
+		try {
+			const upsalesResponse = await upsalesApi.set(PARAM_ID, PARAM_VALUE);
+			expect(true).toBe(false);
+		} catch (err) {
+			expect(true).toBe(true);
+		}
+	});
+
+});

--- a/__tests__/src/api/upsales/currency-test.js
+++ b/__tests__/src/api/upsales/currency-test.js
@@ -1,0 +1,143 @@
+const errorsHelper = require('../../../../src/helpers/errorsHelper');
+const logger = require('../../../../src/helpers/log');
+
+const errors = require('../../../../src/api/upsales/errors');
+
+
+const API_KEY = 'TEST_API_KEY';
+
+
+const getDefaultAxiosOptions = () => {
+	return {
+		method: 'GET',
+		url: 'https://power.upsales.com/api/v2/currencies',
+		headers: {
+			'Cookie': `token=${API_KEY}`,
+			'Content-Type': 'application/json'
+		}
+	};
+};
+
+const getDefaultCurrencies = () => ({
+	data: {
+		data: [
+			{ iso: 'EUR' },
+			{ iso: 'SEK', masterCurrency: true },
+			{ iso: 'USD' },
+			{ iso: 'JPY' }
+		]
+	}
+});
+
+const getDefaultMasterCurrency = () => {
+	return 'SEK';
+}
+
+
+describe('src/api/upsales/currency.js: getCurrencies', () => {
+	beforeEach(() => {
+		jest.resetModules();
+		jest.mock('axios');
+  });
+
+	it('getCurrencies should send correct GET request to acquire currencies from Upsales', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/currency');
+		const axios = require('axios');
+		axios.mockResolvedValue(getDefaultCurrencies());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY }, { axios,	errorsHelper,	logger });
+
+		const currencies = await upsalesApi.getCurrencies();
+
+		expect(currencies).toEqual(getDefaultCurrencies().data.data);
+		expect(axios.mock.calls[0]).toEqual([ getDefaultAxiosOptions() ]);
+	});
+
+	it('getCurrencies should throw exception in case of axios promise rejection', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/currency');
+		const axios = require('axios');
+		axios.mockRejectedValue('Some error');
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY }, { axios,	errorsHelper,	logger });
+
+		try {
+			await upsalesApi.getCurrencies();
+			expect(true).toBe(false);
+		} catch (err) {
+			expect(true).toBe(true);
+		}
+	});
+
+});
+
+
+describe('src/api/upsales/currency.js: getMasterCurrency', () => {
+	beforeEach(() => {
+		jest.resetModules();
+		jest.mock('axios');
+  });
+
+	it('getMasterCurrency should send correct GET request to acquire currencies from Upsales', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/currency');
+		const axios = require('axios');
+		axios.mockResolvedValue(getDefaultCurrencies());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY }, { axios,	errorsHelper,	logger });
+
+ 		await upsalesApi.getMasterCurrency();
+
+		expect(axios.mock.calls[0]).toEqual([ getDefaultAxiosOptions() ]);
+	});
+
+	it('getMasterCurrency should return correct master currency ISO code', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/currency');
+		const axios = require('axios');
+		axios.mockResolvedValue(getDefaultCurrencies());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY }, { axios,	errorsHelper,	logger });
+
+		const masterCurrency = await upsalesApi.getMasterCurrency();
+
+		expect(masterCurrency).toEqual(getDefaultMasterCurrency());
+	});
+
+	it('getMasterCurrency should throw exception in case of axios promise rejection', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/currency');
+		const axios = require('axios');
+		axios.mockRejectedValue('Some error');
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY }, { axios,	errorsHelper,	logger });
+
+		try {
+			await upsalesApi.getMasterCurrency();
+			expect(true).toBe(false);
+		} catch (err) {
+			expect(true).toBe(true);
+		}
+	});
+
+});
+
+
+describe('src/api/upsales/currency.js: findMasterCurrency', () => {
+	beforeEach(() => {
+		jest.resetModules();
+  });
+
+	it('findMasterCurrency should return correct master currency ISO code', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/currency');
+		const upsalesApi = new UpsalesApi({ }, { errorsHelper, logger });
+
+		const masterCurrency = await upsalesApi.findMasterCurrency(getDefaultCurrencies().data.data);
+
+		expect(masterCurrency).toEqual(getDefaultMasterCurrency());
+	});
+
+	it('findMasterCurrency should catch, wrap and re-throw exceptions', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/currency');
+		const upsalesApi = new UpsalesApi({  }, { errorsHelper,	logger });
+
+		try {
+			await upsalesApi.findMasterCurrency();
+			expect(true).toBe(false);
+		} catch (err) {
+			expect(err.code).toBe(errors.FIND_MASTER_CURRENCY_ERROR.code);
+		}
+	});
+
+});

--- a/__tests__/src/api/upsales/customFields-test.js
+++ b/__tests__/src/api/upsales/customFields-test.js
@@ -1,0 +1,1241 @@
+const errorsHelper = require('../../../../src/helpers/errorsHelper');
+const logger = require('../../../../src/helpers/log');
+
+
+
+const getDefaultCustomFieldsMetadata = () => ([
+	{ id: 1, alias: 'ALIAS_1' },
+	{ id: 12, alias: 'ALIAS_2' },
+	{ id: 5, alias: 'ALIAS_10' },
+	{ id: 6, alias: 'ALIAS_3' },
+	{ id: 1001, alias: 'ALIAS_5' },
+	{ id: 6, alias: 'ALIAS_3' },
+	{ id: 1005, alias: 'AlIaS_6' }
+]);
+
+const getVariousCaseCustomFieldsMetadata = () => ([
+	{ id: 1, alias: 'ALIAS_1' },
+	{ id: 12, alias: 'ALIAS_2' },
+	{ id: 5, alias: 'ALIAS_10' },
+	{ id: 6, alias: 'ALIAS_3' },
+	{ id: 1001, alias: 'ALIAS_5' },
+	{ id: 6, alias: 'ALIAS_3' },
+	{ id: 1005, alias: 'AlIaS_6' }
+]);
+
+const getAlteredCustomFieldsMetadata = () => ([
+	{ id: 11, alias: 'ALIAS_1' },
+	{ id: 112, alias: 'ALIAS_2' },
+	{ id: 15, alias: 'ALIAS_10' },
+	{ id: 16, alias: 'ALIAS_3' },
+	{ id: 11001, alias: 'ALIAS_5' },
+	{ id: 16, alias: 'ALIAS_3' },
+	{ id: 11005, alias: 'AlIaS_6' },
+	{ id: 1100, alias: 'ALIAS_7' }
+]);
+
+const getCustomFieldsMetadataWithAbsentAliases = () => ([
+	{ id: 1, alias: 'ALIAS_1' },
+	{ id: 12 },
+	{ id: 5, alias: 'ALIAS_10' },
+	{ id: 6 },
+	{ id: 1001, alias: 'ALIAS_5' },
+	{ id: 6, alias: 'ALIAS_3' },
+	{ id: 1005, alias: 'AlIaS_6' }
+]);
+
+const getCustomFieldsMetadataWithNotStringAliases = () => ([
+	{ id: 1, alias: 'ALIAS_1' },
+	{ id: 12, alias: 5 },
+	{ id: 5, alias: 'ALIAS_10' },
+	{ id: 6, alias: ['some', 'array'] },
+	{ id: 1001, alias: 'ALIAS_5' },
+	{ id: 6, alias: 'ALIAS_3' },
+	{ id: 1005, alias: 'AlIaS_6' }
+]);
+
+const getDefaultCustomFieldsData = () => ([
+	{ fieldId: 1, value: 20 },
+	{ fieldId: 12, value: 30 },
+	{ fieldId: 5, value: 15 },
+	{ fieldId: 6, value: 17 },
+	{ fieldId: 1001, value: 3 },
+	{ fieldId: 6, value: 8 },
+	{ fieldId: 1005, value: 35 }
+]);
+
+const getDefaultObject = () => {
+	return Object.assign({}, {
+		id: 1002,
+		custom: [
+			{ fieldId: 2, value: 'AAA' },
+			{ fieldId: 5, value: 100 }
+		]
+	});
+};
+
+const getObjectWithEmptyCustomFieldsArray = () => {
+	return Object.assign({}, {
+		id: 1002,
+		custom: []
+	});
+};
+
+const getObjectWithUndefinedCustomFieldsArray = () => {
+	return Object.assign({}, {
+		id: 1002,
+	});
+};
+
+const getDefaultFieldsMap = () => ({
+	1: { id: 1, alias: 'ALIAS_1' },
+	'ALIAS_1': { id: 1, alias: 'ALIAS_1' },
+	12: { id: 12, alias: 'ALIAS_2' },
+	'ALIAS_2': { id: 12, alias: 'ALIAS_2' },
+	5: { id: 5, alias: 'ALIAS_10' },
+	'ALIAS_10': { id: 5, alias: 'ALIAS_10' },
+	6: { id: 6, alias: 'ALIAS_3' },
+	'ALIAS_3': { id: 6, alias: 'ALIAS_3' },
+	1001: { id: 1001, alias: 'ALIAS_5' },
+	'ALIAS_5': { id: 1001, alias: 'ALIAS_5' },
+	1005: { id: 1005, alias: 'ALIAS_6' },
+	'ALIAS_6': { id: 1005, alias: 'ALIAS_6' }
+});
+
+const getVariousCaseFieldsMap = () => ({
+	1: { id: 1, alias: 'ALIAS_1' },
+	'ALIAS_1': { id: 1, alias: 'ALIAS_1' },
+	12: { id: 12, alias: 'ALIAS_2' },
+	'ALIAS_2': { id: 12, alias: 'ALIAS_2' },
+	5: { id: 5, alias: 'ALIAS_10' },
+	'ALIAS_10': { id: 5, alias: 'ALIAS_10' },
+	6: { id: 6, alias: 'ALIAS_3' },
+	'ALIAS_3': { id: 6, alias: 'ALIAS_3' },
+	1001: { id: 1001, alias: 'ALIAS_5' },
+	'ALIAS_5': { id: 1001, alias: 'ALIAS_5' },
+	1005: { id: 1005, alias: 'ALIAS_6' },
+	'ALIAS_6': { id: 1005, alias: 'ALIAS_6' }
+});
+
+const getAlteredCustomFieldsMap = () => ({
+	11: { id: 11, alias: 'ALIAS_1' },
+	'ALIAS_1': { id: 11, alias: 'ALIAS_1' },
+	112: { id: 112, alias: 'ALIAS_2' },
+	'ALIAS_2': { id: 112, alias: 'ALIAS_2' },
+	15: { id: 15, alias: 'ALIAS_10' },
+	'ALIAS_10': { id: 15, alias: 'ALIAS_10' },
+	16: { id: 16, alias: 'ALIAS_3' },
+	'ALIAS_3': { id: 16, alias: 'ALIAS_3' },
+	11001: { id: 11001, alias: 'ALIAS_5' },
+	'ALIAS_5': { id: 11001, alias: 'ALIAS_5' },
+	11005: { id: 11005, alias: 'ALIAS_6' },
+	'ALIAS_6': { id: 11005, alias: 'ALIAS_6' },
+	1100: { id: 1100, alias: 'ALIAS_7' },
+	'ALIAS_7': { id: 1100, alias: 'ALIAS_7' }
+});
+
+const getDefaultUpsales = (metadataProvider = getDefaultCustomFieldsMetadata) => ({
+	order: {
+		customfields: {
+			create: jest.fn((data) => {
+				data.id = 1;
+				return data;
+			}),
+			list: jest.fn().mockResolvedValue(metadataProvider())
+		}
+	},
+	account: {
+		customfields: {
+			create: jest.fn((data) => {
+				data.id = 1;
+				return data;
+			}),
+			list: jest.fn().mockResolvedValue(metadataProvider())
+		}
+	}
+});
+
+const getTwoStagedUpsales = (metadataProvider1 = getDefaultCustomFieldsMetadata, metadataProvider2 = getDefaultCustomFieldsMetadata) => ({
+	order: {
+		customfields: {
+			create: jest.fn((data) => {
+				data.id = 1;
+				return data;
+			}),
+			list: jest.fn().mockResolvedValueOnce(metadataProvider1()).mockResolvedValue(metadataProvider2())
+		}
+	}
+});
+
+
+
+describe('src/helpers/customFields.js: findFieldByAlias', () => {
+	beforeEach(() => {
+		jest.resetModules();
+	});
+
+	it('findFieldByAlias should find and return field by alias', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const foundField = customFields.metadata.findFieldByAlias(getDefaultCustomFieldsMetadata(), 'ALIAS_10');
+		expect(foundField).toEqual(getDefaultCustomFieldsMetadata()[2]);
+	});
+
+	it('findFieldByAlias should ignore case of alias parameter', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const foundField = customFields.metadata.findFieldByAlias(getDefaultCustomFieldsMetadata(), 'AlIaS_10');
+		expect(foundField).toEqual(getDefaultCustomFieldsMetadata()[2]);
+	});
+
+	it('findFieldByAlias should ignore case of alias in fields', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const foundField = customFields.metadata.findFieldByAlias(getDefaultCustomFieldsMetadata(), 'ALIAS_6');
+		expect(foundField).toEqual(getDefaultCustomFieldsMetadata()[6]);
+	});
+
+	it('findFieldByAlias should return first occurance if multiple fields with the same alias are found', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const foundField = customFields.metadata.findFieldByAlias(getDefaultCustomFieldsMetadata(), 'ALIAS_3');
+		expect(foundField).toEqual(getDefaultCustomFieldsMetadata()[3]);
+	});
+
+	it('findFieldByAlias should return undefined if field is not found', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const foundField = customFields.metadata.findFieldByAlias(getDefaultCustomFieldsMetadata(), 'ALIAS_NOT_IN_THE_FIELDS');
+		expect(foundField).toBeUndefined();
+	});
+
+	it('findFieldByAlias should return undefined if alias parameter is not specified', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const foundField = customFields.metadata.findFieldByAlias(getDefaultCustomFieldsMetadata());
+		expect(foundField).toBeUndefined();
+	});
+
+	it('findFieldByAlias should return undefined if alias parameter is not string', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const foundField = customFields.metadata.findFieldByAlias(getDefaultCustomFieldsMetadata(), 5);
+		expect(foundField).toBeUndefined();
+	});
+
+	it('findFieldByAlias should return undefined if fields parameter is not specified', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const foundField = customFields.metadata.findFieldByAlias(null, 'ALIAS_5');
+		expect(foundField).toBeUndefined();
+	});
+
+	it('findFieldByAlias should return undefined if fields parameter is not array', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const foundField = customFields.metadata.findFieldByAlias('Some value', 'ALIAS_5');
+		expect(foundField).toBeUndefined();
+	});
+
+	it('findFieldByAlias should ignore fields with absent aliases', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const foundField = customFields.metadata.findFieldByAlias(getCustomFieldsMetadataWithAbsentAliases(), 'ALIAS_5');
+		expect(foundField).toEqual(getCustomFieldsMetadataWithAbsentAliases()[4]);
+	});
+
+	it('findFieldByAlias should ignore fields with not string aliases', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const foundField = customFields.metadata.findFieldByAlias(getCustomFieldsMetadataWithNotStringAliases(), 'ALIAS_5');
+		expect(foundField).toEqual(getCustomFieldsMetadataWithNotStringAliases()[4]);
+	});
+
+});
+
+
+
+describe('src/helpers/customFields.js: getValueById', () => {
+	beforeEach(() => {
+		jest.resetModules();
+	});
+
+	it('getValueById should find field by ID', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const foundField = customFields.getValueById(getDefaultCustomFieldsData(), 5);
+		expect(foundField).toEqual(getDefaultCustomFieldsData()[2].value);
+	});
+
+	it('getValueById should return first occurance if multiple fields with the same ID are found', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const foundField = customFields.getValueById(getDefaultCustomFieldsData(), 6);
+		expect(foundField).toEqual(getDefaultCustomFieldsData()[3].value);
+	});
+
+	it('getValueById should return undefined if ID parameter is not specified', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const foundField = customFields.getValueById(getDefaultCustomFieldsData());
+		expect(foundField).toBeUndefined();
+	});
+
+	it('getValueById should return undefined if fields parameter is not specified', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const foundField = customFields.getValueById(null, 5);
+		expect(foundField).toBeUndefined();
+	});
+
+});
+
+
+
+describe('src/helpers/customFields.js: getValueByAlias', () => {
+	beforeEach(() => {
+		jest.resetModules();
+	});
+
+	it('getValueByAlias should find field value by alias', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const foundValue = await customFields.getValueByAlias(getDefaultCustomFieldsData(), 'order', 'ALIAS_10');
+		expect(foundValue).toEqual(getDefaultCustomFieldsData()[2].value);
+	});
+
+	it('getValueByAlias should return first occurance if multiple fields with the same alias are found', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const foundValue = await customFields.getValueByAlias(getDefaultCustomFieldsData(), 'order', 'ALIAS_3');
+		expect(foundValue).toEqual(getDefaultCustomFieldsData()[3].value);
+	});
+
+	it('getValueByAlias should return undefined if alias parameter is not specified', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const foundValue = await customFields.getValueByAlias(getDefaultCustomFieldsData(), 'order');
+		expect(foundValue).toBeUndefined();
+	});
+
+	it('getValueByAlias should return undefined if fields parameter is not specified', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const foundValue = await customFields.getValueByAlias(null, 'order', 5);
+		expect(foundValue).toBeUndefined();
+	});
+
+	it('getValueByAlias should return undefined if entityType parameter is not specified', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const foundValue = await customFields.getValueByAlias(getDefaultCustomFieldsData(), undefined, 'ALIAS_10');
+		expect(foundValue).toBeUndefined();
+	});
+
+	it('getValueByAlias should return undefined if upsales object is not specified', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+
+		const foundValue = await customFields.getValueByAlias(getDefaultCustomFieldsData(), 'order', 'ALIAS_10');
+		expect(foundValue).toBeUndefined();
+	});
+
+});
+
+
+
+describe('src/helpers/customFields.js: setValueById', () => {
+	beforeEach(() => {
+		jest.resetModules();
+	});
+
+	it('setValueById should add new field to an existing custom fields list', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const alteredObject = customFields.setValueById(getDefaultObject(), 3, 'Test value');
+		expect(alteredObject).toEqual({
+			id: 1002,
+			custom: [
+				{ fieldId: 2, value: 'AAA' },
+				{ fieldId: 5, value: 100 },
+				{ fieldId: 3, value: 'Test value' }
+			]
+		});
+	});
+
+	it('setValueById should alter existing field', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const alteredObject = customFields.setValueById(getDefaultObject(), 5, 'Test value');
+		expect(alteredObject).toEqual({
+			id: 1002,
+			custom: [
+				{ fieldId: 2, value: 'AAA' },
+				{ fieldId: 5, value: 'Test value' }
+			]
+		});
+	});
+
+	it('setValueById should add new field even when custom fields array is empty', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const alteredObject = customFields.setValueById(getObjectWithEmptyCustomFieldsArray(), 3, 'Test value');
+		expect(alteredObject).toEqual({
+			id: 1002,
+			custom: [
+				{ fieldId: 3, value: 'Test value' }
+			]
+		});
+	});
+
+	it('setValueById should add new field even when custom fields list is absent', () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+		const alteredObject = customFields.setValueById(getObjectWithUndefinedCustomFieldsArray(), 3, 'Test value');
+		expect(alteredObject).toEqual({
+			id: 1002,
+			custom: [
+				{ fieldId: 3, value: 'Test value' }
+			]
+		});
+	});
+
+});
+
+
+
+describe('src/helpers/customFields.js: setValueByAlias', () => {
+	beforeEach(() => {
+		jest.resetModules();
+	});
+
+	it('setValueByAlias should add new field to an existing custom fields list', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+    const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const alteredObject = await customFields.setValueByAlias(getDefaultObject(), 'order', 'ALIAS_3', 'Test value');
+		expect(alteredObject).toEqual({
+			id: 1002,
+			custom: [
+				{ fieldId: 2, value: 'AAA' },
+				{ fieldId: 5, value: 100 },
+				{ fieldId: 6, value: 'Test value' }
+			]
+		});
+	});
+
+	it('setValueByAlias should alter existing field', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+    const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const alteredObject = await customFields.setValueByAlias(getDefaultObject(), 'order', 'ALIAS_10', 'Test value');
+		expect(alteredObject).toEqual({
+			id: 1002,
+			custom: [
+				{ fieldId: 2, value: 'AAA' },
+				{ fieldId: 5, value: 'Test value' }
+			]
+		});
+	});
+
+	it('setValueByAlias should add new field even when custom fields array is empty', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+    const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const alteredObject = await customFields.setValueByAlias(getObjectWithEmptyCustomFieldsArray(), 'order', 'ALIAS_3', 'Test value');
+		expect(alteredObject).toEqual({
+			id: 1002,
+			custom: [
+				{ fieldId: 6, value: 'Test value' }
+			]
+		});
+	});
+
+	it('setValueByAlias should add new field even when custom fields list is absent', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+    const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const alteredObject = await customFields.setValueByAlias(getObjectWithUndefinedCustomFieldsArray(), 'order', 'ALIAS_3', 'Test value');
+		expect(alteredObject).toEqual({
+			id: 1002,
+			custom: [
+				{ fieldId: 6, value: 'Test value' }
+			]
+		});
+	});
+
+});
+
+
+
+describe('src/helpers/customFields.js: loadEntityFieldByAlias', () => {
+	beforeEach(() => {
+		jest.resetModules();
+	});
+
+	it('loadEntityFieldByAlias should load custom field by its alias', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const foundField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_10', false);
+		expect(foundField).toEqual(getDefaultCustomFieldsMetadata()[2]);
+	});
+
+	it('loadEntityFieldByAlias should ignore case of alias parameter', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const foundField = await customFields.metadata.loadEntityFieldByAlias('order', 'AlIaS_10', false);
+		expect(foundField).toEqual(getDefaultCustomFieldsMetadata()[2]);
+	});
+
+	it('loadEntityFieldByAlias should ignore case of alias in fields', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const foundField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_6', false);
+		expect(foundField).toEqual(getDefaultCustomFieldsMetadata()[6]);
+	});
+
+	it('loadEntityFieldByAlias should ignore fields with absent aliases', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales(getCustomFieldsMetadataWithAbsentAliases);
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const foundField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_5', false);
+		expect(foundField).toEqual(getDefaultCustomFieldsMetadata()[4]);
+	});
+
+	it('loadEntityFieldByAlias should ignore fields with not string aliases', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales(getCustomFieldsMetadataWithNotStringAliases);
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const foundField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_5', false);
+		expect(foundField).toEqual(getDefaultCustomFieldsMetadata()[4]);
+	});
+
+	it('loadEntityFieldByAlias should return undefined if field not found', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const foundField = await customFields.metadata.loadEntityFieldByAlias('order', 'MISSING_FIELD', false);
+		expect(foundField).toBeUndefined();
+	});
+
+	it('loadEntityFieldByAlias should return undefined if upsales object is not passed', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+
+		const foundField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_5', false);
+		expect(foundField).toBeUndefined();
+	});
+
+	it('loadEntityFieldByAlias should return undefined if alias parameter is not specified', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+
+		const foundField = await customFields.metadata.loadEntityFieldByAlias('order');
+		expect(foundField).toBeUndefined();
+	});
+
+	it('loadEntityFieldByAlias should return undefined if alias parameter is not string', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+
+		const foundField = await customFields.metadata.loadEntityFieldByAlias('order', 5, false);
+		expect(foundField).toBeUndefined();
+	});
+
+	it('loadEntityFieldByAlias should use cached value when acquiring same field', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getTwoStagedUpsales(undefined, getAlteredCustomFieldsMetadata);
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const firstField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_5', true);
+		const secondField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_5', true);
+		expect(secondField).toEqual(getDefaultCustomFieldsMetadata()[4]);
+	});
+
+	it('loadEntityFieldByAlias should use cached list when acquiring another field', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getTwoStagedUpsales(undefined, getAlteredCustomFieldsMetadata);
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const firstField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_5', true);
+		const secondField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_10', true);
+		expect(secondField).toEqual(getDefaultCustomFieldsMetadata()[2]);
+	});
+
+	it('loadEntityFieldByAlias should not access Upsales object second time when acquiring same field using cache', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const firstField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_5', true);
+		const firstCalls = upsales.order.customfields.list.mock.calls.length;
+		const secondField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_5', true);
+		const secondCalls = upsales.order.customfields.list.mock.calls.length;
+		expect(secondCalls).toEqual(firstCalls);
+		expect(secondField).toEqual(getDefaultCustomFieldsMetadata()[4]);
+	});
+
+	it('loadEntityFieldByAlias should not access Upsales object second time when using cache', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const firstField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_5', true);
+		const firstCalls = upsales.order.customfields.list.mock.calls.length;
+		const secondField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_10', true);
+		const secondCalls = upsales.order.customfields.list.mock.calls.length;
+		expect(secondCalls).toEqual(firstCalls);
+		expect(secondField).toEqual(getDefaultCustomFieldsMetadata()[2]);
+	});
+
+	it('loadEntityFieldByAlias should find new field that is absent in cache', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getTwoStagedUpsales(undefined, getAlteredCustomFieldsMetadata);
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const firstField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_5', true);
+		const secondField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_7', true);
+		expect(secondField).toEqual(getAlteredCustomFieldsMetadata()[7]);
+	});
+
+	it('loadEntityFieldByAlias should find field in cache that is absent in Upsales', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getTwoStagedUpsales(getAlteredCustomFieldsMetadata);
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const firstField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_5', true);
+		const secondField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_7', true);
+		expect(secondField).toEqual(getAlteredCustomFieldsMetadata()[7]);
+	});
+
+	it('loadEntityFieldByAlias should not use cached value if caching is switched off', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getTwoStagedUpsales(undefined, getAlteredCustomFieldsMetadata);
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const firstField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_5', true);
+		const secondField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_5', false);
+		expect(secondField).toEqual(getAlteredCustomFieldsMetadata()[4]);
+	});
+
+	it('loadEntityFieldByAlias should not cache values if caching is switched off', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getTwoStagedUpsales(undefined, getAlteredCustomFieldsMetadata);
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const firstField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_5', false);
+		const secondField = await customFields.metadata.loadEntityFieldByAlias('order', 'ALIAS_5', true);
+		expect(secondField).toEqual(getAlteredCustomFieldsMetadata()[4]);
+	});
+
+});
+
+
+
+describe('src/helpers/customFields.js: loadEntityFields', () => {
+	beforeEach(() => {
+		jest.resetModules();
+	});
+
+	it('loadEntityFields should return all custom fields', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const fieldsMap = await customFields.metadata.loadEntityFields('order', true);
+		expect(fieldsMap).toEqual(getDefaultCustomFieldsMetadata());
+	});
+
+	it('loadEntityFields should return all custom fields with upper-case aliases', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales(getVariousCaseCustomFieldsMetadata);
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const fieldsMap = await customFields.metadata.loadEntityFields('order', true);
+		expect(fieldsMap).toEqual(getVariousCaseCustomFieldsMetadata());
+	});
+
+	it('loadEntityFields should return empty Object when no entityType is passed', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const fieldsMap = await customFields.metadata.loadEntityFields();
+		expect(fieldsMap).toEqual({});
+	});
+
+	it('loadEntityFields should return empty Object when no Upsales object is passed', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+
+		const fieldsMap = await customFields.metadata.loadEntityFields('order', true);
+		expect(fieldsMap).toEqual({});
+	});
+
+	it('loadEntityFields should use cache', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getTwoStagedUpsales(undefined, getAlteredCustomFieldsMetadata);
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const fieldsMapFirst = await customFields.metadata.loadEntityFields('order', true);
+		const fieldsMapSecond = await customFields.metadata.loadEntityFields('order', true);
+		expect(fieldsMapSecond).toEqual(getDefaultCustomFieldsMetadata());
+	});
+
+	it('loadEntityFields should not access Upsales object second time when using cache', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const fieldsMapFirst = await customFields.metadata.loadEntityFields('order', true);
+		const firstCalls = upsales.order.customfields.list.mock.calls.length;
+		const fieldsMapSecond = await customFields.metadata.loadEntityFields('order', true);
+		const secondCalls = upsales.order.customfields.list.mock.calls.length;
+		expect(secondCalls).toEqual(firstCalls);
+		expect(fieldsMapSecond).toEqual(getDefaultCustomFieldsMetadata());
+	});
+
+	it('loadEntityFields should not use cache if caching is switched off', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getTwoStagedUpsales(undefined, getAlteredCustomFieldsMetadata);
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const fieldsMapFirst = await customFields.metadata.loadEntityFields('order', true);
+		const fieldsMapSecond = await customFields.metadata.loadEntityFields('order', false);
+		expect(fieldsMapSecond).toEqual(getAlteredCustomFieldsMetadata());
+	});
+
+	it('loadEntityFields should not cache data if caching is switched off', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getTwoStagedUpsales(undefined, getAlteredCustomFieldsMetadata);
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const fieldsMapFirst = await customFields.metadata.loadEntityFields('order', false);
+		const fieldsMapSecond = await customFields.metadata.loadEntityFields('order', true);
+		expect(fieldsMapSecond).toEqual(getAlteredCustomFieldsMetadata());
+	});
+
+});
+
+
+const getDefaultFieldsList = () => {
+	return [
+		{
+			entityType: 'order',
+			fieldDescription: {
+				alias: 'ALIAS_3',
+				name: 'field 3'
+			},
+			comment: 'Order field #3'
+		},
+		{
+			entityType: 'order',
+			fieldDescription: {
+				alias: 'ALIAS_5',
+				name: 'field 5'
+			},
+			comment: 'Order field #5'
+		},
+		{
+			entityType: 'account',
+			fieldDescription: {
+				alias: 'ALIAS_10',
+				name: 'field 10'
+			},
+			comment: 'Account field #10'
+		}
+	];
+};
+
+const getDefaultFieldsResult = () => {
+	return [
+		{	isNew: false, field: { id: 6, alias: 'ALIAS_3' }	},
+		{	isNew: false, field: { id: 1001, alias: 'ALIAS_5' }	},
+		{	isNew: false, field: { id: 5, alias: 'ALIAS_10' }	}
+	];
+};
+
+const getMissingFieldsList = () => {
+	return [
+		{
+			entityType: 'order',
+			fieldDescription: {
+				alias: 'ALIAS_3',
+				name: 'field 3'
+			},
+			comment: 'Order field #3'
+		},
+		{
+			entityType: 'order',
+			fieldDescription: {
+				alias: 'ALIAS_5',
+				name: 'field 5'
+			},
+			comment: 'Order field #5'
+		},
+		{
+			entityType: 'account',
+			fieldDescription: {
+				alias: 'ALIAS_15',
+				name: 'field 15'
+			},
+			comment: 'Order field #15'
+		},
+		{
+			entityType: 'account',
+			fieldDescription: {
+				alias: 'ALIAS_10',
+				name: 'field 10'
+			},
+			comment: 'Account field #10'
+		},
+		{
+			entityType: 'order',
+			fieldDescription: {
+				alias: 'ALIAS_17',
+				name: 'field 17'
+			},
+			comment: 'Order field #17'
+		}
+	];
+};
+
+const getMissingFieldsResult = () => {
+	return [
+		{"field": {"alias": "ALIAS_3", "id": 6}, "isNew": false},
+		{"field": {"alias": "ALIAS_5", "id": 1001}, "isNew": false},
+		{"field": {"alias": "ALIAS_15", "id": 1, "name": "field 15"}, "isNew": true},
+		{"field": {"alias": "ALIAS_10", "id": 5}, "isNew": false},
+		{"field": {"alias": "ALIAS_17", "id": 1, "name": "field 17"}, "isNew": true}
+	];
+};
+
+const getMissingFieldsOrderCreation = () => {
+	return [[{"alias":"ALIAS_17","name":"field 17","id":1}]];
+};
+
+const getMissingFieldsAccountCreationCalls = () => {
+	return [[{"alias":"ALIAS_15","name":"field 15","id":1}]];
+};
+
+const getCaseInsensitiveAliasFieldsList = () => {
+	return [
+		{
+			entityType: 'order',
+			fieldDescription: {
+				alias: 'ALIAS_3',
+				name: 'field 3'
+			},
+			comment: 'Order field #3'
+		},
+		{
+			entityType: 'order',
+			fieldDescription: {
+				alias: 'ALIAS_5',
+				name: 'field 5'
+			},
+			comment: 'Order field #5'
+		},
+		{
+			entityType: 'account',
+			fieldDescription: {
+				alias: 'ALIAS_6',
+				name: 'field 6'
+			},
+			comment: 'Account field #6'
+		}
+	];
+};
+
+const getCaseInsensitiveAliasFieldsResult = () => {
+	return [
+		{	isNew: false, field: { id: 6, alias: 'ALIAS_3' }	},
+		{	isNew: false, field: { id: 1001, alias: 'ALIAS_5' }	},
+		{	isNew: false, field: { id: 1005, alias: 'AlIaS_6' }	}
+	];
+};
+
+const getKeepCaseOfAliasOnCreationFieldsList = () => {
+	return [
+		{
+			entityType: 'order',
+			fieldDescription: {
+				alias: 'ALIAS_3',
+				name: 'field 3'
+			},
+			comment: 'Order field #3'
+		},
+		{
+			entityType: 'order',
+			fieldDescription: {
+				alias: 'ALIAS_5',
+				name: 'field 5'
+			},
+			comment: 'Order field #5'
+		},
+		{
+			entityType: 'account',
+			fieldDescription: {
+				alias: 'AlIaS_15',
+				name: 'field 15'
+			},
+			comment: 'Order field #15'
+		},
+		{
+			entityType: 'account',
+			fieldDescription: {
+				alias: 'ALIAS_10',
+				name: 'field 10'
+			},
+			comment: 'Account field #10'
+		},
+		{
+			entityType: 'order',
+			fieldDescription: {
+				alias: 'AlIaS_17',
+				name: 'field 17'
+			},
+			comment: 'Order field #17'
+		}
+	];
+};
+
+const getKeepCaseOfAliasOnCreationFieldsResult = () => {
+	return [
+		{"field": {"alias": "ALIAS_3", "id": 6}, "isNew": false},
+		{"field": {"alias": "ALIAS_5", "id": 1001}, "isNew": false},
+		{"field": {"alias": "AlIaS_15", "id": 1, "name": "field 15"}, "isNew": true},
+		{"field": {"alias": "ALIAS_10", "id": 5}, "isNew": false},
+		{"field": {"alias": "AlIaS_17", "id": 1, "name": "field 17"}, "isNew": true}
+	];
+};
+
+const getKeepCaseOfAliasOnCreationFieldsOrderCreation = () => {
+	return [[{"alias":"AlIaS_17","name":"field 17","id":1}]];
+};
+
+const getKeepCaseOfAliasOnCreationFieldsAccountCreationCalls = () => {
+	return [[{"alias":"AlIaS_15","name":"field 15","id":1}]];
+};
+
+const getIgnoreAbsentFieldDescriptionFieldsList = () => {
+	return [
+		{
+			entityType: 'order',
+			comment: 'Order field #3'
+		},
+		{
+			entityType: 'order',
+			fieldDescription: {
+				alias: 'ALIAS_5',
+				name: 'field 5'
+			},
+			comment: 'Order field #5'
+		},
+		{
+			entityType: 'account',
+			comment: 'Order field #15'
+		},
+		{
+			entityType: 'account',
+			fieldDescription: {
+				alias: 'ALIAS_10',
+				name: 'field 10'
+			},
+			comment: 'Account field #10'
+		},
+		{
+			entityType: 'order',
+			fieldDescription: {
+				alias: 'ALIAS_17',
+				name: 'field 17'
+			},
+			comment: 'Order field #17'
+		}
+	];
+};
+
+const getIgnoreAbsentFieldDescriptionFieldsResult = () => {
+	return [
+		{"field": {"alias": "ALIAS_5", "id": 1001}, "isNew": false},
+		{"field": {"alias": "ALIAS_10", "id": 5}, "isNew": false},
+		{"field": {"alias": "ALIAS_17", "id": 1, "name": "field 17"}, "isNew": true}
+	];
+};
+
+const getIgnoreAbsentFieldDescriptionFieldsOrderCreation = () => {
+	return [[{"alias":"ALIAS_17","name":"field 17","id":1}]];
+};
+
+const getIgnoreAbsentFieldDescriptionFieldsAccountCreationCalls = () => {
+	return [];
+};
+
+const getIgnoreAbsentEntityTypeFieldsList = () => {
+	return [
+		{
+			fieldDescription: {
+				alias: 'ALIAS_3',
+				name: 'field 3'
+			},
+			comment: 'Order field #3'
+		},
+		{
+			entityType: 'order',
+			fieldDescription: {
+				alias: 'ALIAS_5',
+				name: 'field 5'
+			},
+			comment: 'Order field #5'
+		},
+		{
+			entityType: 'account',
+			fieldDescription: {
+				alias: 'ALIAS_15',
+				name: 'field 15'
+			},
+			comment: 'Order field #15'
+		},
+		{
+			entityType: 'account',
+			fieldDescription: {
+				alias: 'ALIAS_10',
+				name: 'field 10'
+			},
+			comment: 'Account field #10'
+		},
+		{
+			fieldDescription: {
+				alias: 'ALIAS_17',
+				name: 'field 17'
+			},
+			comment: 'Order field #17'
+		}
+	];
+};
+
+const getIgnoreAbsentEntityTypeFieldsResult = () => {
+	return [
+		{"field": {"alias": "ALIAS_5", "id": 1001}, "isNew": false},
+		{"field": {"alias": "ALIAS_15", "id": 1, "name": "field 15"}, "isNew": true},
+		{"field": {"alias": "ALIAS_10", "id": 5}, "isNew": false},
+	];
+};
+
+const getIgnoreAbsentEntityTypeFieldsOrderCreation = () => {
+	return [];
+};
+
+const getIgnoreAbsentEntityTypeFieldsAccountCreationCalls = () => {
+	return [[{"alias":"ALIAS_15","name":"field 15","id":1}]];
+};
+
+
+describe('src/helpers/customFields.js: ensureFieldsExist', () => {
+	beforeEach(() => {
+		jest.resetModules();
+	});
+
+	it('ensureFieldsExist should find several existing fields for different entities', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const result = await customFields.metadata.ensureFieldsExist(getDefaultFieldsList(), true);
+		expect(result).toEqual(getDefaultFieldsResult());
+	});
+
+	it('ensureFieldsExist should not create new field if existing is found (several fields for different entities)', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const result = await customFields.metadata.ensureFieldsExist(getDefaultFieldsList(), true);
+		expect(upsales.order.customfields.create.mock.calls.length).toEqual(0);
+		expect(upsales.account.customfields.create.mock.calls.length).toEqual(0);
+	});
+
+	it('ensureFieldsExist should create several missing fields for different entities', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const result = await customFields.metadata.ensureFieldsExist(getMissingFieldsList(), true);
+		expect(result).toEqual(getMissingFieldsResult());
+		expect(upsales.order.customfields.create.mock.calls).toEqual(getMissingFieldsOrderCreation());
+		expect(upsales.account.customfields.create.mock.calls).toEqual(getMissingFieldsAccountCreationCalls());
+	});
+
+	it('ensureFieldsExist should find several existing fields (alias case insensitive) for different entities', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const result = await customFields.metadata.ensureFieldsExist(getCaseInsensitiveAliasFieldsList(), true);
+		expect(result).toEqual(getCaseInsensitiveAliasFieldsResult());
+		expect(upsales.order.customfields.create.mock.calls.length).toEqual(0);
+		expect(upsales.account.customfields.create.mock.calls.length).toEqual(0);
+	});
+
+	it('ensureFieldsExist should keep alias case when creating fields', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const result = await customFields.metadata.ensureFieldsExist(getKeepCaseOfAliasOnCreationFieldsList(), true);
+		expect(result).toEqual(getKeepCaseOfAliasOnCreationFieldsResult());
+		expect(upsales.order.customfields.create.mock.calls).toEqual(getKeepCaseOfAliasOnCreationFieldsOrderCreation());
+		expect(upsales.account.customfields.create.mock.calls).toEqual(getKeepCaseOfAliasOnCreationFieldsAccountCreationCalls());
+	});
+
+	it('ensureFieldsExist should safely ignore absent field desсription', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const result = await customFields.metadata.ensureFieldsExist(getIgnoreAbsentFieldDescriptionFieldsList(), true);
+		expect(result).toEqual(getIgnoreAbsentFieldDescriptionFieldsResult());
+		expect(upsales.order.customfields.create.mock.calls).toEqual(getIgnoreAbsentFieldDescriptionFieldsOrderCreation());
+		expect(upsales.account.customfields.create.mock.calls).toEqual(getIgnoreAbsentFieldDescriptionFieldsAccountCreationCalls());
+	});
+
+	it('ensureFieldsExist should safely ignore absent entity type', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const result = await customFields.metadata.ensureFieldsExist(getIgnoreAbsentEntityTypeFieldsList(), true);
+		expect(result).toEqual(getIgnoreAbsentEntityTypeFieldsResult());
+		expect(upsales.order.customfields.create.mock.calls).toEqual(getIgnoreAbsentEntityTypeFieldsOrderCreation());
+		expect(upsales.account.customfields.create.mock.calls).toEqual(getIgnoreAbsentEntityTypeFieldsAccountCreationCalls());
+	});
+
+	it('ensureFieldsExist should safely ignore absent Upsales object', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const customFields = new CustomFields({}, { errorsHelper, logger });
+
+		const result = await customFields.metadata.ensureFieldsExist(getMissingFieldsList(), true);
+		expect(result).toEqual([]);
+	});
+
+	it('ensureFieldsExist should support passing and returning one object instead of custom fields list', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getDefaultUpsales();
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const result = await customFields.metadata.ensureFieldsExist(getDefaultFieldsList()[0], true);
+		expect(result).toEqual(getDefaultFieldsResult()[0]);
+	});
+/*
+
+	it('ensureFieldsExist should use cache if caching is switched on', async () => {
+	});
+
+	it('ensureFieldsExist should not use cached value if caching is switched off', async () => {
+	});
+
+	it('ensureFieldsExist should not cache data if caching is switched off', async () => {
+	});
+*/
+
+/*
+	it('ensureFieldsExist should use cache', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getTwoStagedUpsales(getAlteredCustomFieldsMetadata);
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const fieldDescription = {
+			alias: 'ALIAS_7',
+			name: 'new field'
+		};
+		const firstField = await customFields.metadata.ensureFieldsExist([{entityType: 'order', fieldDescription}], true);
+		const secondField = await customFields.metadata.ensureFieldsExist([{entityType: 'order', fieldDescription}], true);
+		expect(secondField).toEqual({
+			field: {
+				id: 1100,
+				alias: 'ALIAS_7'
+			},
+			isNew: false
+		});
+	});
+
+	it('ensureFieldsExist should not use cached value if caching is switched off', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getTwoStagedUpsales(getAlteredCustomFieldsMetadata);
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const fieldDescription = {
+			alias: 'ALIAS_7',
+			name: 'new field'
+		};
+		const firstField = await customFields.metadata.ensureFieldsExist([{entityType: 'order', fieldDescription}], true);
+		const secondField = await customFields.metadata.ensureFieldsExist([{entityType: 'order', fieldDescription}], false);
+		const secondCalls = upsales.order.customfields.create.mock.calls.length;
+		expect(secondCalls).toBe(1);
+		expect(secondField).toEqual({
+			field: {
+				id: 1,
+				alias: 'ALIAS_7',
+				name: 'new field'
+			},
+			isNew: true
+		});
+	});
+
+	it('ensureFieldsExist should not cache data if caching is switched off', async () => {
+		const CustomFields = require('../../../../src/api/upsales/customFields');
+		const upsales = getTwoStagedUpsales(getAlteredCustomFieldsMetadata);
+		const customFields = new CustomFields({}, { upsales, errorsHelper, logger });
+
+		const fieldDescription = {
+			alias: 'ALIAS_7',
+			name: 'new field'
+		};
+		const firstField = await customFields.metadata.ensureFieldsExist([{entityType: 'order', fieldDescription}], false);
+		const secondField = await customFields.metadata.ensureFieldsExist([{entityType: 'order', fieldDescription}], true);
+		const secondCalls = upsales.order.customfields.create.mock.calls.length;
+		expect(secondCalls).toBe(1);
+		expect(secondField).toEqual({
+			field: {
+				id: 1,
+				alias: 'ALIAS_7',
+				name: 'new field'
+			},
+			isNew: true
+		});
+	});
+*/
+});
+
+
+describe('src/helpers/customFields.js: clearCache', () => {
+	beforeEach(() => {
+		jest.resetModules();
+	});
+
+	
+});

--- a/__tests__/src/api/upsales/dynamicLink-test.js
+++ b/__tests__/src/api/upsales/dynamicLink-test.js
@@ -1,0 +1,224 @@
+const errorsHelper = require('../../../../src/helpers/errorsHelper');
+const logger = require('../../../../src/helpers/log');
+
+const getNewDynamicLink = () => ({ data: 'RESULT' });
+
+const getDynamicLinks = () => ({
+	data: {
+		data: [
+			{ id: 1, href: 'aaa' },
+			{ id: 2, href: 'EXISTING_LINK' },
+			{ id: 3, href: 'ccc' }
+		]
+	}
+});
+
+const getNoDataResponse = () => ({
+});
+
+const getDynamicLinkSingleObject = () => ({
+	data: {
+		data: { id: 2, href: 'EXISTING_LINK' }
+	}
+});
+
+const API_KEY = 'TEST_API_KEY';
+const INTEGRATION_ID = 277;
+
+
+
+describe('src/api/upsales/dynamicLink.js: createDynamicLink', () => {
+	beforeEach(() => {
+		jest.resetModules();
+		jest.mock('axios');
+  });
+
+	it('createDynamicLink should send POST request to create Dynamic link', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/dynamicLink');
+		const axios = require('axios');
+		axios.post.mockResolvedValue(getNewDynamicLink());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY }, { axios,	errorsHelper,	logger });
+
+		const linkObject = {
+			href: 'SOME_LINK'
+		};
+
+		const createdLink = await upsalesApi.createDynamicLink(linkObject);
+
+		expect(createdLink).toEqual(getNewDynamicLink().data);
+		expect(axios.post.mock.calls).toEqual([ [ 'https://power.upsales.com/api/v2/link?token=' + API_KEY, linkObject ] ]);
+	});
+
+	it('createDynamicLink should throw exception in case of axios promise rejection', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/dynamicLink');
+		const axios = require('axios');
+		axios.post.mockRejectedValue('Some error');
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY }, { axios,	errorsHelper,	logger });
+
+		const linkObject = {
+			href: 'SOME_LINK'
+		};
+
+		try {
+			const createdLink = await upsalesApi.createDynamicLink(linkObject);
+			expect(true).toBe(false);
+		} catch (err) {
+			expect(true).toBe(true);
+		}
+	});
+
+});
+
+
+
+describe('src/api/upsales/dynamicLink.js: loadDynamicLinks', () => {
+	beforeEach(() => {
+		jest.resetModules();
+		jest.mock('axios');
+  });
+
+	it('loadDynamicLinks should send GET request to acquire Dynamic links list from Upsales', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/dynamicLink');
+		const axios = require('axios');
+		axios.get.mockResolvedValue(getDynamicLinks());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY }, { axios,	errorsHelper,	logger });
+
+		const links = await upsalesApi.loadDynamicLinks();
+
+		expect(links).toEqual(getDynamicLinks().data.data);
+		expect(axios.get.mock.calls).toEqual([ [ 'https://power.upsales.com/api/v2/link?token=' + API_KEY ] ]);
+	});
+
+	it('loadDynamicLinks should throw exception in case of axios promise rejection', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/dynamicLink');
+		const axios = require('axios');
+		axios.get.mockRejectedValue('Some error');
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY }, { axios,	errorsHelper,	logger });
+
+		try {
+			const links = await upsalesApi.loadDynamicLinks();
+			expect(true).toBe(false);
+		} catch (err) {
+			expect(true).toBe(true);
+		}
+	});
+
+	it('loadDynamicLinks should return empty array if Upsales response contains no `data` field', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/dynamicLink');
+		const axios = require('axios');
+		axios.get.mockResolvedValue(getNoDataResponse());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY }, { axios,	errorsHelper,	logger });
+
+		const links = await upsalesApi.loadDynamicLinks();
+
+		expect(links).toEqual([]);
+		expect(axios.get.mock.calls).toEqual([ [ 'https://power.upsales.com/api/v2/link?token=' + API_KEY ] ]);
+	});
+
+});
+
+
+
+describe('src/api/upsales/dynamicLink.js: createDynamicLinkIfNecessary', () => {
+	beforeEach(() => {
+		jest.resetModules();
+		jest.mock('axios');
+  });
+
+	it('createDynamicLinkIfNecessary should send POST request to create Dynamic link if no such Dynamic link exists', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/dynamicLink');
+		const axios = require('axios');
+		axios.post.mockResolvedValue(getNewDynamicLink());
+		axios.get.mockResolvedValue(getDynamicLinks());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY }, { axios,	errorsHelper,	logger });
+
+		const linkObject = {
+			href: 'SOME_LINK'
+		};
+
+		const createdLink = await upsalesApi.createDynamicLinkIfNecessary(linkObject);
+
+		expect(createdLink).toEqual(getNewDynamicLink().data);
+		expect(axios.get.mock.calls).toEqual([ [ 'https://power.upsales.com/api/v2/link?token=' + API_KEY ] ]);
+		expect(axios.post.mock.calls).toEqual([ [ 'https://power.upsales.com/api/v2/link?token=' + API_KEY, linkObject ] ]);
+	});
+
+	it('createDynamicLinkIfNecessary should not send POST request to create Dynamic link if such Dynamic link already exists', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/dynamicLink');
+		const axios = require('axios');
+		axios.post.mockResolvedValue(getNewDynamicLink());
+		axios.get.mockResolvedValue(getDynamicLinks());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY }, { axios,	errorsHelper,	logger });
+
+		const linkObject = {
+			href: 'EXISTING_LINK'
+		};
+
+		const createdLink = await upsalesApi.createDynamicLinkIfNecessary(linkObject);
+
+		expect(createdLink).toBeUndefined();
+		expect(axios.get.mock.calls).toEqual([ [ 'https://power.upsales.com/api/v2/link?token=' + API_KEY ] ]);
+	});
+
+	it('createDynamicLinkIfNecessary should support single-object lists of Dynamic links', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/dynamicLink');
+		const axios = require('axios');
+		axios.post.mockResolvedValue(getNewDynamicLink());
+		axios.get.mockResolvedValue(getDynamicLinkSingleObject());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY }, { axios,	errorsHelper,	logger });
+
+		const linkObject = {
+			href: 'SOME_LINK'
+		};
+		const createdLink = await upsalesApi.createDynamicLinkIfNecessary(linkObject);
+
+		const linkObject2 = {
+			href: 'EXISTING_LINK'
+		};
+		const createdLink2 = await upsalesApi.createDynamicLinkIfNecessary(linkObject2);
+
+		expect(createdLink).toEqual(getNewDynamicLink().data);
+		expect(createdLink2).toBeUndefined();
+		expect(axios.get.mock.calls).toEqual([
+			[ 'https://power.upsales.com/api/v2/link?token=' + API_KEY ],
+		 	[ 'https://power.upsales.com/api/v2/link?token=' + API_KEY ]
+		]);
+		expect(axios.post.mock.calls).toEqual([ [ 'https://power.upsales.com/api/v2/link?token=' + API_KEY, linkObject ] ]);
+	});
+
+	it('createDynamicLinkIfNecessary should throw exception in case of axios promise rejection when creating Dynamic link', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/dynamicLink');
+		const axios = require('axios');
+		axios.post.mockRejectedValue('Some error');
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY }, { axios,	errorsHelper,	logger });
+
+		const linkObject = {
+			href: 'SOME_LINK'
+		};
+
+		try {
+			const createdLink = await upsalesApi.createDynamicLinkIfNecessary(linkObject);
+			expect(true).toBe(false);
+		} catch (err) {
+			expect(true).toBe(true);
+		}
+	});
+
+	it('createDynamicLinkIfNecessary should create Dyamic Link in case of axios rejection when retrieving Dynamic links list', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/dynamicLink');
+		const axios = require('axios');
+		axios.post.mockResolvedValue(getNewDynamicLink());
+		axios.get.mockRejectedValue('Some error');
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY }, { axios,	errorsHelper,	logger });
+
+		const linkObject = {
+			href: 'SOME_LINK'
+		};
+
+		const createdLink = await upsalesApi.createDynamicLinkIfNecessary(linkObject);
+		expect(createdLink).toEqual(getNewDynamicLink().data);
+		expect(axios.get.mock.calls).toEqual([ [ 'https://power.upsales.com/api/v2/link?token=' + API_KEY ] ]);
+		expect(axios.post.mock.calls).toEqual([ [ 'https://power.upsales.com/api/v2/link?token=' + API_KEY, linkObject ] ]);
+	});
+
+});

--- a/__tests__/src/api/upsales/externalCall-test.js
+++ b/__tests__/src/api/upsales/externalCall-test.js
@@ -1,0 +1,63 @@
+const errorsHelper = require('../../../../src/helpers/errorsHelper');
+const logger = require('../../../../src/helpers/log');
+
+const CUSTOMER_ID = '1002';
+const AUTHENTICATION_KEY = 'somekey';
+const APP_ID = 300;
+const DATA = {
+	field1: 'data1',
+	field2: 'some data 2'
+};
+
+const getCallHookOptions = () => {
+	return {
+		method: 'POST',
+		url: `https://integration.upsales.com/api/external/appHook?customerId=${CUSTOMER_ID}&authenticationKey=${AUTHENTICATION_KEY}&appId=${APP_ID}`,
+		headers: {
+			'Content-Type': 'application/json'
+		},
+		data: DATA
+	};
+};
+
+const getCallHookPostResponse = () => {
+	return {
+		data: 'SOME_RESULT'
+	};
+};
+
+
+
+describe('src/api/upsales/externalCall.js: callHook', () => {
+	beforeEach(() => {
+		jest.resetModules();
+		jest.mock('axios');
+  });
+
+	it('callHook should send correct POST request to Upsales to call app hook', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/externalCall');
+		const axios = require('axios');
+		axios.mockResolvedValue(getCallHookPostResponse());
+		const upsalesApi = new UpsalesApi({ integrationId: APP_ID, authenticationKey: AUTHENTICATION_KEY }, { axios,	errorsHelper,	logger });
+
+		const upsalesResponse = await upsalesApi.callHook(CUSTOMER_ID, DATA);
+
+		expect(upsalesResponse).toEqual(getCallHookPostResponse().data);
+		expect(axios.mock.calls[0]).toEqual([ getCallHookOptions() ]);
+	});
+
+	it('callHook should throw exception in case of axios promise rejection', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/externalCall');
+		const axios = require('axios');
+		axios.mockRejectedValue('Some error');
+		const upsalesApi = new UpsalesApi({ integrationId: APP_ID, authenticationKey: AUTHENTICATION_KEY }, { axios,	errorsHelper,	logger });
+
+		try {
+			const upsalesResponse = await upsalesApi.callHook(CUSTOMER_ID, DATA);
+			expect(true).toBe(false);
+		} catch (err) {
+			expect(true).toBe(true);
+		}
+	});
+
+});

--- a/__tests__/src/api/upsales/uiNotification-test.js
+++ b/__tests__/src/api/upsales/uiNotification-test.js
@@ -1,0 +1,250 @@
+const errorsHelper = require('../../../../src/helpers/errorsHelper');
+const logger = require('../../../../src/helpers/log');
+
+const API_KEY = 'TEST_API_KEY';
+const IMPORT_ID = 199;
+const ALTERNATE_IMPORT_ID = 210;
+const CALLBACK_URL = 'http://some.callback.url/';
+const ALTERNATE_CALLBACK_URL = 'http://alternate.callback.url/';
+const PROGRESS = 75;
+const NOTIFICATION = 'some message';
+const ERROR_TEXT = 'error message';
+
+const getDefaultSendProgressOptions = () => {
+	return {
+		method: 'PUT',
+		url: `https://power.upsales.com/api/v2/onboardingimports/${IMPORT_ID}`,
+		headers: {
+			'Cookie': `token=${API_KEY}`,
+			'Content-Type': 'application/json'
+		},
+		data: {
+			id: IMPORT_ID,
+			progress: PROGRESS
+		}
+	};
+};
+
+const getAlternateSendProgressOptions = () => {
+	return {
+		method: 'PUT',
+		url: `https://power.upsales.com/api/v2/onboardingimports/${ALTERNATE_IMPORT_ID}`,
+		headers: {
+			'Cookie': `token=${API_KEY}`,
+			'Content-Type': 'application/json'
+		},
+		data: {
+			id: ALTERNATE_IMPORT_ID,
+			progress: PROGRESS
+		}
+	};
+};
+
+
+const getDefaultSendMessageOptions = () => {
+	return {
+		method: 'POST',
+		url: CALLBACK_URL,
+		headers: {
+			'Cookie': `token=${API_KEY}`,
+			'Content-Type': 'application/json'
+		},
+		data: {
+			notify: NOTIFICATION
+		}
+	}
+};
+
+const getAlternateSendMessageOptions = () => {
+	return {
+		method: 'POST',
+		url: ALTERNATE_CALLBACK_URL,
+		headers: {
+			'Cookie': `token=${API_KEY}`,
+			'Content-Type': 'application/json'
+		},
+		data: {
+			notify: NOTIFICATION
+		}
+	}
+};
+
+
+const getDefaultSendErrorOptions = () => {
+	return {
+		method: 'POST',
+		url: CALLBACK_URL,
+		headers: {
+			'Cookie': `token=${API_KEY}`,
+			'Content-Type': 'application/json'
+		},
+		data: {
+			message: ERROR_TEXT,
+			notify: ERROR_TEXT
+		}
+	}
+};
+
+const getAlternateSendErrorOptions = () => {
+	return {
+		method: 'POST',
+		url: ALTERNATE_CALLBACK_URL,
+		headers: {
+			'Cookie': `token=${API_KEY}`,
+			'Content-Type': 'application/json'
+		},
+		data: {
+			message: ERROR_TEXT,
+			notify: ERROR_TEXT
+		}
+	}
+};
+
+
+const getDefaultUpsalesResponse = () => {
+	return {
+		data: 'SOME_RESULT'
+	};
+};
+
+
+
+describe('src/api/upsales/uiNotification.js: safeSendProgress', () => {
+	beforeEach(() => {
+		jest.resetModules();
+		jest.mock('axios');
+  });
+
+	it('safeSendProgress should send correct PUT request to Upsales', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/uiNotification');
+		const axios = require('axios');
+		axios.mockResolvedValue(getDefaultUpsalesResponse());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, importId: IMPORT_ID }, { axios,	errorsHelper,	logger });
+
+		const upsalesResponse = await upsalesApi.safeSendProgress(PROGRESS);
+
+		expect(upsalesResponse).toEqual(getDefaultUpsalesResponse().data);
+		expect(axios.mock.calls[0]).toEqual([ getDefaultSendProgressOptions() ]);
+	});
+
+	it('safeSendProgress should use alternateImportId if specified', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/uiNotification');
+		const axios = require('axios');
+		axios.mockResolvedValue(getDefaultUpsalesResponse());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, importId: IMPORT_ID }, { axios,	errorsHelper,	logger });
+
+		const upsalesResponse = await upsalesApi.safeSendProgress(PROGRESS, ALTERNATE_IMPORT_ID);
+
+		expect(upsalesResponse).toEqual(getDefaultUpsalesResponse().data);
+		expect(axios.mock.calls[0]).toEqual([ getAlternateSendProgressOptions() ]);
+	});
+
+	it('safeSendProgress should silently ignore axios promise rejection', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/uiNotification');
+		const axios = require('axios');
+		axios.mockRejectedValue('Some error');
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, importId: IMPORT_ID }, { axios,	errorsHelper,	logger });
+
+		try {
+			const upsalesResponse = await upsalesApi.safeSendProgress(PROGRESS);
+			expect(true).toBe(true);
+		} catch (err) {
+			expect(true).toBe(false);
+		}
+	});
+
+});
+
+
+describe('src/api/upsales/uiNotification.js: safeSendMessage', () => {
+	beforeEach(() => {
+		jest.resetModules();
+		jest.mock('axios');
+  });
+
+	it('safeSendMessage should send correct PUT request to Upsales', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/uiNotification');
+		const axios = require('axios');
+		axios.mockResolvedValue(getDefaultUpsalesResponse());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, callbackUrl: CALLBACK_URL }, { axios,	errorsHelper,	logger });
+
+		const upsalesResponse = await upsalesApi.safeSendMessage(NOTIFICATION);
+
+		expect(upsalesResponse).toEqual(getDefaultUpsalesResponse().data);
+		expect(axios.mock.calls[0]).toEqual([ getDefaultSendMessageOptions() ]);
+	});
+
+	it('safeSendMessage should use alternateImportId if specified', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/uiNotification');
+		const axios = require('axios');
+		axios.mockResolvedValue(getDefaultUpsalesResponse());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, callbackUrl: CALLBACK_URL }, { axios,	errorsHelper,	logger });
+
+		const upsalesResponse = await upsalesApi.safeSendMessage(NOTIFICATION, ALTERNATE_CALLBACK_URL);
+
+		expect(upsalesResponse).toEqual(getDefaultUpsalesResponse().data);
+		expect(axios.mock.calls[0]).toEqual([ getAlternateSendMessageOptions() ]);
+	});
+
+	it('safeSendMessage should silently ignore axios promise rejection', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/uiNotification');
+		const axios = require('axios');
+		axios.mockRejectedValue('Some error');
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, callbackUrl: CALLBACK_URL }, { axios,	errorsHelper,	logger });
+
+		try {
+			const upsalesResponse = await upsalesApi.safeSendMessage(NOTIFICATION);
+			expect(true).toBe(true);
+		} catch (err) {
+			expect(true).toBe(false);
+		}
+	});
+
+});
+
+
+describe('src/api/upsales/uiNotification.js: safeSendError', () => {
+	beforeEach(() => {
+		jest.resetModules();
+		jest.mock('axios');
+  });
+
+	it('safeSendError should send correct PUT request to Upsales', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/uiNotification');
+		const axios = require('axios');
+		axios.mockResolvedValue(getDefaultUpsalesResponse());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, callbackUrl: CALLBACK_URL }, { axios,	errorsHelper,	logger });
+
+		const upsalesResponse = await upsalesApi.safeSendError(ERROR_TEXT);
+
+		expect(upsalesResponse).toEqual(getDefaultUpsalesResponse().data);
+		expect(axios.mock.calls[0]).toEqual([ getDefaultSendErrorOptions() ]);
+	});
+
+	it('safeSendError should use alternateImportId if specified', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/uiNotification');
+		const axios = require('axios');
+		axios.mockResolvedValue(getDefaultUpsalesResponse());
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, callbackUrl: CALLBACK_URL }, { axios,	errorsHelper,	logger });
+
+		const upsalesResponse = await upsalesApi.safeSendError(ERROR_TEXT, ALTERNATE_CALLBACK_URL);
+
+		expect(upsalesResponse).toEqual(getDefaultUpsalesResponse().data);
+		expect(axios.mock.calls[0]).toEqual([ getAlternateSendErrorOptions() ]);
+	});
+
+	it('safeSendError should silently ignore axios promise rejection', async () => {
+		const UpsalesApi = require('../../../../src/api/upsales/uiNotification');
+		const axios = require('axios');
+		axios.mockRejectedValue('Some error');
+		const upsalesApi = new UpsalesApi({ apiKey: API_KEY, callbackUrl: CALLBACK_URL }, { axios,	errorsHelper,	logger });
+
+		try {
+			const upsalesResponse = await upsalesApi.safeSendError(ERROR_TEXT);
+			expect(true).toBe(true);
+		} catch (err) {
+			expect(true).toBe(false);
+		}
+	});
+
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1416,14 +1416,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1438,20 +1436,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -1568,8 +1563,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -1581,7 +1575,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -1596,7 +1589,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -1604,14 +1596,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -1630,7 +1620,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -1711,8 +1700,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -1724,7 +1712,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -1846,7 +1833,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -5672,6 +5658,14 @@
         "statuses": "~1.4.0"
       }
     },
+    "serialize-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
+      "integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
+      "requires": {
+        "type-fest": "^0.8.0"
+      }
+    },
     "serve-static": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
@@ -6197,6 +6191,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "type-is": {
       "version": "1.6.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -467,6 +467,22 @@
       "requires": {
         "axios": "^0.18.0",
         "axios-retry": "^3.1.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+          "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+          "requires": {
+            "follow-redirects": "1.5.10",
+            "is-buffer": "^2.0.2"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        }
       }
     },
     "abab": {
@@ -932,12 +948,19 @@
       "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
       "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+        }
       }
     },
     "axios-retry": {
@@ -1393,12 +1416,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -1413,17 +1438,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -1540,7 +1568,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -1552,6 +1581,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -1566,6 +1596,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -1573,12 +1604,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -1597,6 +1630,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -1677,7 +1711,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -1689,6 +1724,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -1810,6 +1846,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -2749,25 +2786,20 @@
       }
     },
     "follow-redirects": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
-      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
-        "debug": "^3.2.6"
+        "debug": "=3.1.0"
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
         "@upsales/node-upsales": "^1.0.0",
         "@upsales/node-upsales-promise": "^1.3.3",
         "aws-serverless-express": "^3.3.5",
+        "axios": "^0.19.0",
+        "axios-retry": "^3.1.2",
         "bumpme": "^1.1.1",
         "dotenv": "^5.0.1",
         "express": "^4.16.4",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "dotenv": "^5.0.1",
         "express": "^4.16.4",
         "jest": "^24.5.0",
+        "serialize-error": "^5.0.0",
         "winston": "^2.4.4"
     },
     "jest": {

--- a/src/api/upsales/appConfig.js
+++ b/src/api/upsales/appConfig.js
@@ -1,0 +1,95 @@
+/**
+ * Upsales API app config accessing wrapper
+ */
+const errors = require('./errors');
+const requiredInput = require('../../helpers/errorsHelper').requiredInput;
+
+/**
+ * Represents an Upsales API app config accessing wrapper
+ * @constructor
+ * @param {object} options - access keys and other options (apiKey, integrationId)
+ * @param {object} dependencies - dependencies (axios, errorsHelper, logger)
+ */
+module.exports = function ({ apiKey, integrationId } = requiredInput('options'), { axios, errorsHelper, logger } = requiredInput('dependencies')) {
+
+  /**
+   * Load app config from Upsales
+   * @async
+   * @return {object} app config
+   *         Note:config itself will reside in configJson field as a JSON string
+   * @throws Will throw an error if some error occures during HTTP request to Upsales server
+   */
+  const load = async () => {
+    try {
+      const upsalesAppConfigApiUrl = `https://power.upsales.com/api/v2/standardIntegrationSettings/${integrationId}?token=${apiKey}`;
+      const appConfig = await axios.get(upsalesAppConfigApiUrl).then(result => result.data.data);
+      return appConfig;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.LOAD_UPSALES_APP_CONFIG_ERROR, err);
+      logger.error(errorToReport);
+      throw errorToReport;
+    }
+  };
+
+
+  /**
+   * Save app config to Upsales
+   * @async
+   * @param {object} appConfig - an app config to save
+   * @returns {object} response from Upsales server
+   * @throws Will throw an error if some error occures during HTTP request to Upsales server
+   */
+  const save = async (appConfig) => {
+    try {
+      const upsalesAppConfigApiUrl = `https://power.upsales.com/api/v2/standardIntegrationSettings/${integrationId}?token=${apiKey}`;
+      const upsalesResponse = await axios.put(upsalesAppConfigApiUrl, appConfig).then(result => result.data);
+      return upsalesResponse;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.SAVE_UPSALES_APP_CONFIG_ERROR, err);
+      logger.error(errorToReport);
+      throw errorToReport;
+    }
+  };
+
+
+  /**
+   * Update specified fields of app config at Upsales
+   * @async
+   * @param {array<object>} changes - list of changes to apply to app config ([{name:'field_name', value:'value_to_set'}, ...])
+   * @returns {boolean} true if app config has changed, false if none of the fields actually changed
+   * @throws Will throw an error if some error occures during HTTP request to Upsales server
+   */
+  const updateFields = async (changes) => {
+    try {
+      const appConfig = await load();
+      const parsedAppConfig = JSON.parse(appConfig.configJson);
+
+      let hasChanges = false;
+
+      for (let { name, value } of changes) {
+        if (parsedAppConfig[name] != value) {
+          hasChanges = true;
+          parsedAppConfig[name] = value;
+        }
+      }
+
+      if (hasChanges) {
+        appConfig.configJson = JSON.stringify(parsedAppConfig);
+        await save(appConfig);
+      }
+
+      return hasChanges;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.UPDATE_UPSALES_APP_CONFIG_ERROR, err);
+      logger.error(errorToReport);
+      throw errorToReport;
+    }
+
+  };
+
+
+  return { load, save, updateFields };
+};

--- a/src/api/upsales/clientParam.js
+++ b/src/api/upsales/clientParam.js
@@ -1,0 +1,36 @@
+const errors = require('./errors');
+const requiredInput = require('../../helpers/errorsHelper').requiredInput;
+
+module.exports = function ({ apiKey } = requiredInput('options'), { axios, errorsHelper, logger } = requiredInput('dependencies')) {
+
+  const set = async (paramId, value) => {
+    try {
+      logger.info('Setting upsales client parameter...');
+      const options = {
+        method: 'PUT',
+        url: `https://power.upsales.com/api/v2/master/clientParam/${paramId}`,
+        headers: {
+          'Cookie': `token=${apiKey}`,
+          'Content-Type': 'application/json'
+        },
+        data: value
+      };
+
+      logger.info('Sending Upsales API request to set client parameter...');
+      const upsalesResponse = await axios(options).then(result => {
+        logger.info('Upsales client parameter has been set.');
+        return result.data;
+      });
+
+      return upsalesResponse;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.SET_UPSALES_CLIENT_PARAM_ERROR, err);
+      logger.error(errorToReport);
+      throw errorToReport;
+    }
+  };
+
+
+  return { set };
+};

--- a/src/api/upsales/currency.js
+++ b/src/api/upsales/currency.js
@@ -1,0 +1,60 @@
+const errors = require('./errors');
+const requiredInput = require('../../helpers/errorsHelper').requiredInput;
+
+module.exports = function ({ apiKey } = requiredInput('options'), { axios, errorsHelper, logger } = requiredInput('dependencies')) {
+
+  const getCurrencies = async () => {
+    try {
+      logger.info('Getting Upsales currencies...');
+      const options = {
+        method: 'GET',
+        url: 'https://power.upsales.com/api/v2/currencies',
+        headers: {
+          'Cookie': `token=${apiKey}`,
+          'Content-Type': 'application/json'
+        }
+      };
+
+      logger.info('Sending Upsales API request to get currencies...');
+      const currencies = (await axios(options)).data.data;
+      logger.info('Upsales currencies retrieved.');
+
+      return currencies;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.UPSALES_GET_CURRENCIES_ERROR, err);
+      logger.error(errorToReport);
+      throw errorToReport;
+    }
+  };
+
+
+  const findMasterCurrency = (currencies) => {
+    try {
+      const foundCurrency = currencies.find((element) => element.masterCurrency);
+      return foundCurrency.iso;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.FIND_MASTER_CURRENCY_ERROR, err);
+      logger.error(errorToReport);
+      throw errorToReport;
+    }
+  };
+
+
+  const getMasterCurrency = async () => {
+    try {
+      logger.info('Getting master currency...');
+      const currencies = await getCurrencies(apiKey);
+      return findMasterCurrency(currencies);
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.UPSALES_GET_MASTER_CURRENCY_ERROR, err);
+      logger.error(errorToReport);
+      throw errorToReport;
+    }
+  };
+
+
+  return { getMasterCurrency, findMasterCurrency, getCurrencies };
+};

--- a/src/api/upsales/customFields.js
+++ b/src/api/upsales/customFields.js
@@ -1,0 +1,315 @@
+const Cache = require('./helpers/customFieldsCache');
+const errors = require('./errors');
+const requiredInput = require('../../helpers/errorsHelper').requiredInput;
+
+module.exports = function (options, { upsales, errorsHelper, logger } = requiredInput('dependencies')) {
+  const cache = Cache();
+
+
+  const clearCache = (entityType) => {
+    cache.clear(entityType);
+  }
+
+
+  const getById = (customFields, fieldId) => {
+    try {
+      if (!customFields || !Array.isArray(customFields)) {
+        return;
+      }
+
+      const field = customFields.find((element) => {
+        return element.fieldId == fieldId;
+      });
+
+      return field;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.FIND_CUSTOM_FIELD_BY_ID_ERROR, err);
+      logger.error(errorToReport);
+    }
+  };
+
+
+  const getByAlias = async (customFields, entityType, alias, cached = true) => {
+    try {
+      if (!customFields || !Array.isArray(customFields)) {
+        return;
+      }
+
+      const fieldMetadata = await loadEntityFieldByAlias(entityType, alias, cached);
+      if (!fieldMetadata) {
+        logger.info(`Could not find ${entityType} custom field ${alias}.`);
+        return;
+      }
+
+      const fieldId = fieldMetadata.id;
+
+      const field = customFields.find((element) => {
+        return element.fieldId == fieldId;
+      });
+
+      return field;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.FIND_CUSTOM_FIELD_BY_ALIAS_ERROR, err);
+      logger.error(errorToReport);
+    }
+  };
+
+
+  const getValueById = (customFields, fieldId) => {
+    try {
+      const field = getById(customFields, fieldId);
+      if (!field) {
+        return;
+      }
+      return field.value;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.FIND_CUSTOM_FIELD_VALUE_BY_ID_ERROR, err);
+      logger.error(errorToReport);
+    }
+  };
+
+
+  const getValueByAlias = async (customFields, entityType, alias, cached = true) => {
+    try {
+      const field = await getByAlias(customFields, entityType, alias, cached);
+      if (!field) {
+        return;
+      }
+      return field.value;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.FIND_CUSTOM_FIELD_VALUE_BY_ALIAS_ERROR, err);
+      logger.error(errorToReport);
+    }
+  };
+
+
+  const setById = (upsalesEntity, field) => {
+    try {
+      if (!upsalesEntity.custom) {
+        upsalesEntity.custom = [];
+      }
+
+      const fieldIndex = upsalesEntity.custom.findIndex((element) => {
+        return element.fieldId == field.fieldId;
+      });
+
+      if (fieldIndex < 0) {
+        upsalesEntity.custom.push(field);
+
+      } else {
+        upsalesEntity.custom.splice(fieldIndex, 1, field);
+      }
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.SET_CUSTOM_FIELD_VALUE_ERROR, err);
+      logger.error(errorToReport);
+    }
+
+    return upsalesEntity;
+  };
+
+
+  const setByAlias = async (upsalesEntity, entityType, alias, field, cached = true) => {
+    const metadata = await loadEntityFieldByAlias(entityType, alias, cached);
+    if (!metadata) {
+      return upsalesEntity;
+    }
+
+    field.fieldId = metadata.id;
+    return setById(upsalesEntity, field);
+  };
+
+
+  const setValueById = (upsalesEntity, fieldId, value) => {
+    return setById(upsalesEntity,
+      {
+        fieldId: fieldId,
+        value: value
+      }
+    );
+  };
+
+
+  const setValueByAlias = async (upsalesEntity, entityType, alias, value, cached = true) => {
+    return await setByAlias(upsalesEntity, entityType, alias, {
+      value: value
+    }, cached);
+  };
+
+
+  const findFieldByAlias = (fields, alias) => {
+    const safeAliasEqualsFunc = (element) => {
+      try {
+        return element.alias.toUpperCase() == alias;
+      } catch (err) {
+        //Ignore any errors
+      }
+    };
+
+    try {
+      alias = alias.toUpperCase();
+      return fields.find(safeAliasEqualsFunc);
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.FIND_CUSTOM_FIELD_BY_ALIAS_ERROR, err);
+      logger.error(errorToReport);
+    }
+  };
+
+
+  const loadEntityFields = async (entityType, cached = true) => {
+    try {
+      let customFields;
+
+      if (cached) {
+        customFields = cache.getEntityFields(entityType);
+      }
+
+      if (!customFields || customFields.length == 0) {
+        customFields = await upsales[entityType].customfields.list();
+        if (cached) {
+          cache.replaceFields(entityType, customFields);
+        }
+      }
+
+      return customFields;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.LOAD_ENTITY_FIELDS_ERROR, err);
+      logger.error(errorToReport);
+    }
+
+    return {};
+  }
+
+
+  const loadEntityFieldByAlias = async (entityType, alias, cached = true) => {
+    try {
+      let foundField;
+
+      if (cached) {
+        foundField = cache.getByAlias(entityType, alias);
+      }
+
+      if (!foundField) {
+        const customFields = await upsales[entityType].customfields.list();
+        foundField = findFieldByAlias(customFields, alias);
+
+        if (cached) {
+          cache.replaceFields(entityType, customFields);
+        }
+      }
+
+      return foundField;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.LOAD_CUSTOM_FIELD_BY_ALIAS_ERROR, err);
+      logger.error(errorToReport);
+    }
+  };
+
+
+  const ensureOneFieldExist = async (entityType, fieldDescription, cached = true) => {
+    let field;
+    let isNew = false;
+
+    try {
+      const fieldAlias = fieldDescription.alias.toUpperCase();
+      const fieldName = fieldDescription.name;
+
+      try {
+        logger.info('Retrieve ' + fieldName + ' field...');
+        field = await loadEntityFieldByAlias(entityType, fieldAlias, cached);
+      } catch (err) {
+        const errorToReport = errorsHelper.wrapError(errors.ENSURE_CUSTOM_FIELDS_EXIST_POSSIBLE_ERROR, err);
+        logger.debug(errorToReport);
+      }
+
+      if (field == null) {
+        logger.info(fieldName + ' field not found. Creating one...');
+        const data = Object.assign({}, fieldDescription);
+
+        field = await upsales[entityType].customfields.create(data);
+        isNew = true;
+
+        if (field && cached) {
+          cache.addField(entityType, field);
+        }
+
+        logger.info(fieldName + ' field created.');
+      } else {
+        logger.info(fieldName + ' field found.');
+      }
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.ENSURE_ONE_CUSTOM_FIELD_EXIST_ERROR, err);
+      logger.error(errorToReport);
+    }
+
+    if (!field) {
+      return;
+    }
+
+    return {
+      field: field,
+      isNew: isNew
+    };
+  };
+
+
+  const ensureFieldsExist = async (customFieldsList, cached = true) => {
+    try {
+      const isArrayReceived = Array.isArray(customFieldsList);
+      if (!isArrayReceived) {
+        customFieldsList = [ customFieldsList ];
+      }
+
+      const results = [];
+      for (const fieldMetadata of customFieldsList) {
+        logger.info('Check field: ' + fieldMetadata.comment);
+        const field = await ensureOneFieldExist(fieldMetadata.entityType, fieldMetadata.fieldDescription, cached);
+        logger.info('Finished: Check field: ' + fieldMetadata.comment);
+
+        if (field) {
+          results.push(field);
+        }
+      }
+
+      if (isArrayReceived) {
+        return results;
+      } else {
+        return results[0];
+      }
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.ENSURE_CUSTOM_FIELDS_EXIST_ERROR, err);
+      logger.error(errorToReport);
+    }
+  };
+
+
+  return {
+    metadata: {
+      ensureFieldsExist,
+      findFieldByAlias,
+      loadEntityFieldByAlias,
+      loadEntityFields
+    },
+
+    clearCache,
+
+    getByAlias,
+    getById,
+    getValueByAlias,
+    getValueById,
+
+    setByAlias,
+    setById,
+    setValueByAlias,
+    setValueById
+  };
+
+};

--- a/src/api/upsales/dynamicLink.js
+++ b/src/api/upsales/dynamicLink.js
@@ -1,0 +1,71 @@
+const errors = require('./errors');
+const requiredInput = require('../../helpers/errorsHelper').requiredInput;
+
+module.exports = function ({ apiKey } = requiredInput('options'), { axios, errorsHelper, logger } = requiredInput('dependencies')) {
+
+  const createDynamicLink = async (linkObject) => {
+    try {
+      const upsalesPowerApiUrl = 'https://power.upsales.com/api/v2/link?token=' + apiKey;
+      const upsalesResponse = await axios.post(upsalesPowerApiUrl, linkObject).then(result => result.data);
+      return upsalesResponse;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.UPSALES_CREATE_DYNAMIC_LINK_ERROR, err);
+      logger.error(errorToReport);
+    }
+  }
+
+
+  const loadDynamicLinks = async () => {
+    try {
+      const upsalesPowerApiUrl = 'https://power.upsales.com/api/v2/link?token=' + apiKey;
+      const upsalesResponse = await axios.get(upsalesPowerApiUrl).then(result => result.data ? result.data.data : []);
+      return upsalesResponse;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.UPSALES_LOAD_DYNAMIC_LINK_ERROR, err);
+      logger.error(errorToReport);
+    }
+  }
+
+
+  const isDynamicLinkExist = async (linkObject) => {
+    try {
+      let links = await loadDynamicLinks();
+      if (links && !Array.isArray(links)) {
+        links = [ links ];
+      }
+
+      const existingLink = links.find(element => { return element.href == linkObject.href});
+      if (existingLink) {
+        return true;
+      }
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.UPSALES_IS_DYNAMIC_LINK_EXIST_ERROR, err);
+      logger.error(errorToReport);
+    }
+
+    return false;
+  };
+
+
+  const createDynamicLinkIfNecessary = async (linkObject) => {
+    try {
+      if (await isDynamicLinkExist(linkObject)) {
+        logger.info('Dynamic link already exists.');
+        return;
+      }
+
+      logger.info('Creating new dynamic link...');
+      return await createDynamicLink(linkObject);
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.UPSALES_CREATE_DYNAMIC_LINK_IF_NECESSARY_ERROR, err);
+      logger.error(errorToReport);
+    }
+  };
+
+
+  return { createDynamicLink, createDynamicLinkIfNecessary, isDynamicLinkExist, loadDynamicLinks };
+};

--- a/src/api/upsales/errors.js
+++ b/src/api/upsales/errors.js
@@ -1,0 +1,126 @@
+module.exports = {
+  FIND_CUSTOM_FIELD_BY_ID_ERROR: {
+    code: 'FIND_CUSTOM_FIELD_BY_ID_ERROR',
+    message: 'Finding custom field by ID failed with exception'
+  },
+
+  FIND_CUSTOM_FIELD_BY_ALIAS_ERROR: {
+    code: 'FIND_CUSTOM_FIELD_BY_ALIAS_ERROR',
+    message: 'Finding custom field by Alias failed with exception'
+  },
+
+  FIND_CUSTOM_FIELD_VALUE_BY_ID_ERROR: {
+    code: 'FIND_CUSTOM_FIELD_VALUE_BY_ID_ERROR',
+    message: 'Finding custom field value by ID failed with exception'
+  },
+
+  FIND_CUSTOM_FIELD_VALUE_BY_ALIAS_ERROR: {
+    code: 'FIND_CUSTOM_FIELD_VALUE_BY_ALIAS_ERROR',
+    message: 'Finding custom field value by Alias failed with exception'
+  },
+
+  SET_CUSTOM_FIELD_VALUE_ERROR: {
+    code: 'SET_CUSTOM_FIELD_VALUE_ERROR',
+    message: 'Setting custom field value failed with exception'
+  },
+
+  LOAD_CUSTOM_FIELD_BY_ALIAS_ERROR: {
+    code: 'LOAD_CUSTOM_FIELD_BY_ALIAS_ERROR',
+    message: 'Loading custom field by alias failed with exception'
+  },
+
+  ENSURE_CUSTOM_FIELDS_EXIST_POSSIBLE_ERROR: {
+    code: 'ENSURE_CUSTOM_FIELDS_EXIST_POSSIBLE_ERROR',
+    message: 'Creating custom fields might have failed with exception'
+  },
+
+  ENSURE_ONE_CUSTOM_FIELD_EXIST_ERROR: {
+    code: 'ENSURE_ONE_CUSTOM_FIELD_EXIST_ERROR',
+    message: 'Creating one custom field failed with exception'
+  },
+
+  ENSURE_CUSTOM_FIELDS_EXIST_ERROR: {
+    code: 'ENSURE_CUSTOM_FIELDS_EXIST_ERROR',
+    message: 'Creating custom fields failed with exception'
+  },
+
+  LOAD_UPSALES_APP_CONFIG_ERROR: {
+    code: 'LOAD_UPSALES_APP_CONFIG_ERROR',
+    message: 'Getting app config from Upsales failed'
+  },
+
+  SAVE_UPSALES_APP_CONFIG_ERROR: {
+    code: 'SAVE_UPSALES_APP_CONFIG_ERROR',
+    message: 'Saving app config at Upsales failed'
+  },
+
+  UPDATE_UPSALES_APP_CONFIG_ERROR: {
+    code: 'UPDATE_UPSALES_APP_CONFIG_ERROR',
+    message: 'Updating fields in app config at Upsales failed'
+  },
+
+  SET_UPSALES_CLIENT_PARAM_ERROR: {
+    code: 'SET_UPSALES_CLIENT_PARAM_ERROR',
+    message: 'Some error has occured while setting Upsales client parameter'
+  },
+
+  UPSALES_GET_CURRENCIES_ERROR: {
+    code: 'UPSALES_GET_CURRENCIES_ERROR',
+    message: 'Some error has occured while getting Upsales currencies'
+  },
+
+  FIND_MASTER_CURRENCY_ERROR: {
+    code: 'FIND_MASTER_CURRENCY_ERROR',
+    message: 'Some error has occured while searching for master currency among all the currencies'
+  },
+
+  UPSALES_GET_MASTER_CURRENCY_ERROR: {
+    code: 'UPSALES_GET_MASTER_CURRENCY_ERROR',
+    message: 'Some error has occured while acquiring master currency from Upsales'
+  },
+
+  UPSALES_UI_SEND_PROGRESS_ERROR: {
+    code: 'UPSALES_UI_SEND_PROGRESS_ERROR',
+    message: 'Some error has occured while sending progress to Upsales UI'
+  },
+
+  UPSALES_UI_SEND_ERROR_ERROR: {
+    code: 'UPSALES_UI_SEND_ERROR_ERROR',
+    message: 'Some error has occured while sending Error message to Upsales UI'
+  },
+
+  UPSALES_UI_SEND_MESSAGE_ERROR: {
+    code: 'UPSALES_UI_SEND_MESSAGE_ERROR',
+    message: 'Some error has occured while sending message to Upsales UI'
+  },
+
+  UPSALES_CREATE_DYNAMIC_LINK_ERROR: {
+    code: 'UPSALES_CREATE_DYNAMIC_LINK_ERROR',
+    message: 'Dynamic link creation at Upsales failed with error'
+  },
+
+  UPSALES_LOAD_DYNAMIC_LINK_ERROR: {
+    code: 'UPSALES_LOAD_DYNAMIC_LINK_ERROR',
+    message: 'Dynamic links retrieving at Upsales failed with error'
+  },
+
+  UPSALES_IS_DYNAMIC_LINK_EXIST_ERROR: {
+    code: 'UPSALES_IS_DYNAMIC_LINK_EXIST_ERROR',
+    message: 'Some error has occured while checking Upsales dynamic link existance'
+  },
+
+  UPSALES_CREATE_DYNAMIC_LINK_IF_NECESSARY_ERROR: {
+    code: 'UPSALES_CREATE_DYNAMIC_LINK_IF_NECESSARY_ERROR',
+    message: 'Dynamic link existance checking and creation at Upsales failed with error'
+  },
+
+  LOAD_ENTITY_FIELDS_ERROR:  {
+    code: 'LOAD_ENTITY_FIELDS_ERROR',
+    message: 'Unexpected loading entity fields error'
+  },
+
+  SEND_UPSALES_EXTERNAL_APP_HOOK_ERROR: {
+    code: 'SEND_UPSALES_EXTERNAL_APP_HOOK_ERROR',
+    message: 'Calling Upsales external hook failed unexpectedly'
+  }
+};

--- a/src/api/upsales/externalCall.js
+++ b/src/api/upsales/externalCall.js
@@ -1,0 +1,37 @@
+const errors = require('./errors');
+const requiredInput = require('../../helpers/errorsHelper').requiredInput;
+
+module.exports = function ({ integrationId, authenticationKey } = requiredInput('options'), { axios, errorsHelper, logger } = requiredInput('dependencies')) {
+
+  const callHook = async (customerId, data) => {
+    try {
+      logger.info('Calling Upsales app external hook...');
+      const options = {
+        method: 'POST',
+        url: `https://integration.upsales.com/api/external/appHook?customerId=${customerId}&authenticationKey=${authenticationKey}&appId=${integrationId}`,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        data: data
+      };
+
+      logger.info('  Sending Upsales API request to execute an external hook...');
+      logger.debug(options);
+      const upsalesResponse = await axios(options).then(result => {
+        logger.info('  Upsales API request to execute an external hook is sent.');
+        logger.debug(result);
+        return result.data;
+      });
+
+      return upsalesResponse;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.SEND_UPSALES_EXTERNAL_APP_HOOK_ERROR, err);
+      logger.error(errorToReport);
+      throw errorToReport;
+    }
+  };
+
+
+  return { callHook };
+};

--- a/src/api/upsales/helpers/customFieldsCache.js
+++ b/src/api/upsales/helpers/customFieldsCache.js
@@ -1,0 +1,162 @@
+module.exports = function () {
+  let cache = { };
+
+
+  const clear = (entityType) => {
+    try {
+      if (!entityType) {
+        cache = {};
+
+      } else {
+        initEmptyRoots();
+
+        cache.fieldsList[entityType] = {};
+        cache.byAlias[entityType] = {};
+        cache.byId[entityType] = {};
+      }
+    } catch (ex) {
+      //Ignore errors
+    }
+  };
+
+
+  const initEmptyRoots = () => {
+    try {
+      if (!cache.fieldsList) {
+        cache.fieldsList = {};
+      }
+
+      if (!cache.byAlias) {
+        cache.byAlias = {};
+      }
+
+      if (!cache.byId) {
+        cache.byId = {};
+      }
+    } catch (ex) {
+      //Ignore errors
+    }
+  };
+
+
+  const initEmptyEntityRoots = (entityType) => {
+    try {
+      initEmptyRoots();
+
+      if (!cache.fieldsList[entityType]) {
+        cache.fieldsList[entityType] = [];
+      }
+
+      if (!cache.byAlias[entityType]) {
+        cache.byAlias[entityType] = {};
+      }
+
+      if (!cache.byId[entityType]) {
+        cache.byId[entityType] = {};
+      }
+    } catch (ex) {
+      //Ignore errors
+    }
+  };
+
+
+  const replaceFields = (entityType, fields) => {
+    try {
+      initEmptyEntityRoots(entityType);
+
+      cache.fieldsList[entityType] = [];
+      cache.byAlias[entityType] = {};
+
+      for (const field of fields) {
+        addField(entityType, field);
+      }
+    } catch (ex) {
+      //Ignore errors
+    }
+  };
+
+
+  const addField = (entityType, field) => {
+    try {
+      initEmptyEntityRoots(entityType);
+
+      cache.fieldsList[entityType].push(field);
+
+      try {
+        cache.byAlias[entityType][field.alias.toUpperCase()] = field;
+      } catch (ex) {
+        //Ignore errors
+      }
+
+      try {
+        cache.byId[entityType][field.id] = field;
+      } catch (ex) {
+        //Ignore errors
+      }
+    } catch (ex) {
+      //Ignore errors
+    }
+  };
+
+
+  const getEntityFields = (entityType) => {
+    try {
+      initEmptyEntityRoots(entityType);
+      return cache.fieldsList[entityType];
+    } catch (ex) {
+      //Ignore errors
+    }
+  };
+
+
+  const getEntityFieldsByAliasMap = (entityType) => {
+    try {
+      initEmptyEntityRoots(entityType);
+      return cache.byAlias[entityType];
+    } catch (ex) {
+      //Ignore errors
+    }
+  };
+
+
+  const getEntityFieldsByIdMap = (entityType) => {
+    try {
+      initEmptyEntityRoots(entityType);
+      return cache.byId[entityType];
+    } catch (ex) {
+      //Ignore errors
+    }
+  };
+
+
+  const getByAlias = (entityType, alias) => {
+    try {
+      initEmptyEntityRoots(entityType);
+      return cache.byAlias[entityType][alias.toUpperCase()];
+    } catch (err) {
+      //Ignore errors
+    }
+  };
+
+
+  const getById = (entityType, id) => {
+    try {
+      initEmptyEntityRoots(entityType);
+      return cache.byId[entityType][id];
+    } catch (err) {
+      //Ignore errors
+    }
+  };
+
+
+  return {
+    addField,
+    clear,
+    getByAlias,
+    getById,
+    getEntityFields,
+    getEntityFieldsByAliasMap,
+    getEntityFieldsByIdMap,
+    replaceFields
+  };
+};

--- a/src/api/upsales/index.js
+++ b/src/api/upsales/index.js
@@ -1,0 +1,43 @@
+/**
+ * Upsales API wrapper
+ */
+
+const axios = require('axios');
+const axiosRetry = require('axios-retry');
+
+const AppConfig = require('./appConfig');
+const ClientParam = require('./clientParam');
+const Currency = require('./currency');
+const CustomFields = require('./customFields');
+const ExternalCall = require('./externalCall');
+const DynamicLink = require('./dynamicLink');
+const UINotification = require('./uiNotification');
+
+const requiredInput = require('../../helpers/errorsHelper').requiredInput;
+
+
+axiosRetry(axios, {
+  retries: 6,
+  retryDelay: axiosRetry.exponentialDelay
+});
+
+
+/**
+ * Represents an Upsales API wrapper
+ * @constructor
+ * @param {object} options - access keys and other options (apiKey, integrationId, callbackUrl, importId)
+ * @param {object} dependencies - dependencies of the Upsales API wrapper
+ */
+module.exports = function (options = requiredInput('options'), { upsales, logger, errorsHelper } = requiredInput('dependencies')) {
+  const dependencies = { axios, errorsHelper, logger, upsales };
+
+  const appConfig = new AppConfig(options, dependencies);
+  const clientParam = new ClientParam(options, dependencies);
+  const currency = new Currency(options, dependencies);
+  const customFields = new CustomFields(options, dependencies);
+  const externalCall = new ExternalCall(options, dependencies);
+  const dynamicLink = new DynamicLink(options, dependencies);
+  const uiNotification = new UINotification(options, dependencies);
+
+  return { appConfig, clientParam, currency, customFields, entity: upsales, externalCall, uiNotification };
+};

--- a/src/api/upsales/uiNotification.js
+++ b/src/api/upsales/uiNotification.js
@@ -1,0 +1,87 @@
+const errors = require('./errors');
+const requiredInput = require('../../helpers/errorsHelper').requiredInput;
+
+module.exports = function ({ apiKey, callbackUrl='', importId='' } = requiredInput('options'), { axios, errorsHelper, logger } = requiredInput('dependencies')) {
+
+  const safeSendProgress = async (progress, alternateImportId) => {
+    try {
+      const actualImportId = alternateImportId ? alternateImportId : importId;
+
+      const options = {
+        method: 'PUT',
+        url: `https://power.upsales.com/api/v2/onboardingimports/${actualImportId}`,
+        headers: {
+          'Cookie': `token=${apiKey}`,
+          'Content-Type': 'application/json'
+        },
+        data: {
+          id: actualImportId,
+          progress: progress
+        }
+      };
+
+      logger.info('Sending progress: ' + progress);
+      const upsalesResponse = await axios(options).then(result => {
+        logger.info('Progress sent successfully: ' + progress);
+        return result.data;
+      });
+      return upsalesResponse;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.UPSALES_UI_SEND_PROGRESS_ERROR, err);
+      logger.error(errorToReport);
+    }
+  };
+
+
+  const safeSendError = async (errorText, alternateCallbackUrl) => {
+    try {
+      const upsalesResponse = await safeSendMessage({
+        message: errorText,
+        notify: errorText
+      }, alternateCallbackUrl);
+      return upsalesResponse;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.UPSALES_UI_SEND_ERROR_ERROR, err);
+      logger.error(errorToReport);
+    }
+  };
+
+
+  const safeSendMessage = async (notification, alternateCallbackUrl) => {
+    try {
+      const actualCallbackUrl = alternateCallbackUrl ? alternateCallbackUrl : callbackUrl;
+
+      if (typeof notification === 'string') {
+        notification = {
+          notify: notification
+        };
+      }
+
+      const options = {
+        method: 'POST',
+        url: actualCallbackUrl,
+        headers: {
+          'Cookie': `token=${apiKey}`,
+          'Content-Type': 'application/json'
+        },
+        data: notification
+      };
+
+      logger.info('Sending message to UI: ' + notification.notify);
+      const upsalesResponse = await axios(options).then(result => {
+        logger.info('Message to UI sent successfully: ' + notification.notify);
+        return result.data;
+      });
+      return upsalesResponse;
+
+    } catch (err) {
+      const errorToReport = errorsHelper.wrapError(errors.UPSALES_UI_SEND_MESSAGE_ERROR, err);
+      logger.error(errorToReport);
+    }
+  };
+
+
+  return { safeSendError, safeSendMessage, safeSendProgress };
+};

--- a/src/helpers/errorsHelper.js
+++ b/src/helpers/errorsHelper.js
@@ -1,0 +1,41 @@
+const serializeError = require('serialize-error');
+
+
+const requiredInput = (name) => {
+  throw {
+    code: 'REQUIRED_FUNCTION_PARAMETER_MISSING',
+    message: `Parameter ${name} is required`
+  };
+};
+
+
+const wrapError = (options, cause) => {
+  try {
+    let serializedError;
+    if (!cause) {
+      cause = options.cause;
+    }
+    if (cause) {
+      serializedError = serializeError(cause);
+
+      if (!serializedError) {
+        serializedError = JSON.stringify(cause);
+      }
+    }
+
+    return {
+      code: options.code ? options.code : '',
+      message: options.message ? options.message : '',
+      cause: serializedError
+    }
+  } catch (err) {
+    //Ignore errors
+    return options;
+  }
+};
+
+
+module.exports = {
+  requiredInput: requiredInput,
+  wrapError: wrapError
+};


### PR DESCRIPTION
I've included my Upsales API wrapper that I keep adding features to from one project to another.

It implements working via API with some features of:
custom fields (lots of stuff that makes life easier)
app config,
client parameters,
currencies,
dynamic links,
ui notifications,
external hooks.

It is almost 100% covered with unit-tests.
I do not have many comments there or usage examples. But I have a lot of actual usages in my projects code-base. So, I can extract some of them and add-up to form kind of a manual.